### PR TITLE
Reset ProgressModal defaults only on open

### DIFF
--- a/src/components/ProgressModal.jsx
+++ b/src/components/ProgressModal.jsx
@@ -1,5 +1,5 @@
 // src/components/ProgressModal.jsx
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import axios from "axios";
 import Alert from "./Alert.jsx";
 
@@ -10,8 +10,18 @@ import Alert from "./Alert.jsx";
  *  - projectId: string | number (obrigatório)
  *  - eventId?: string | number  (opcional, mas melhora o vínculo)
  *  - onSaved?: () => void       (callback após salvar)
+ *  - defaultWords?: number      (pré-preenche o campo de palavras)
+ *  - defaultNote?: string       (pré-preenche o campo de notas)
  */
-export default function ProgressModal({ open, onClose, projectId, eventId, onSaved }) {
+export default function ProgressModal({
+  open,
+  onClose,
+  projectId,
+  eventId,
+  onSaved,
+  defaultWords,
+  defaultNote,
+}) {
   const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
   const [words, setWords] = useState("");
   const [source, setSource] = useState("manual");
@@ -20,16 +30,25 @@ export default function ProgressModal({ open, onClose, projectId, eventId, onSav
   const [err, setErr] = useState("");
   const [msg, setMsg] = useState("");
 
+  const wasOpen = useRef(false);
+
   useEffect(() => {
-    if (open) {
+    const justOpened = open && !wasOpen.current;
+    wasOpen.current = open;
+
+    if (justOpened) {
       setErr("");
       setMsg("");
-      setWords("");
+      setWords(
+        defaultWords === undefined || defaultWords === null || Number(defaultWords) <= 0
+          ? ""
+          : String(defaultWords)
+      );
       setSource("manual");
-      setNotes("");
+      setNotes(defaultNote ? String(defaultNote) : "");
       setDate(new Date().toISOString().slice(0, 10));
     }
-  }, [open]);
+  }, [open, defaultWords, defaultNote]);
 
   const valid = useMemo(() => {
     const n = Number(words);


### PR DESCRIPTION
## Summary
- ensure ProgressModal only reapplies default words and notes when the modal is newly opened
- avoid overwriting user edits while they interact with the modal by tracking the last open state

## Testing
- npm run build *(fails: vite binary not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8235eeae08332984b3bba267e7bdf