### PR TITLE
Fix buddies and regions routes and API imports

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,8 @@ import Validate from "./pages/Validate.jsx";
 import Certificate from "./pages/Certificate.jsx";
 import Events from "./pages/Events.jsx";
 import WritingDiary from "./pages/WritingDiary.jsx"; // << Diário da Escrita
+import RegionsLeaderboard from "./pages/RegionsLeaderboard.jsx";
+import Buddies from "./pages/Buddies.jsx";
 
 export default function App() {
   const [loginOpen, setLoginOpen] = useState(false);
@@ -151,13 +153,21 @@ export default function App() {
           }
         />
         <Route
-  path="/regions"
-  element={
-    <ProtectedRoute>
-      <RegionsLeaderboard />
-    </ProtectedRoute>
-  }
-/>
+          path="/regions"
+          element={
+            <ProtectedRoute>
+              <RegionsLeaderboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/buddies"
+          element={
+            <ProtectedRoute>
+              <Buddies />
+            </ProtectedRoute>
+          }
+        />
 
         {/* Opcional: rota 404
         <Route path="*" element={<NotFound />} />

--- a/src/api/buddies.js
+++ b/src/api/buddies.js
@@ -1,5 +1,5 @@
 // src/api/buddies.js
-import { api } from "./client"; // seu wrapper (axios/fetch) já existente
+import api from "./http"; // wrapper axios já existente
 
 export async function listBuddies() {
   const { data } = await api.get("/buddies");

--- a/src/api/regions.js
+++ b/src/api/regions.js
@@ -1,4 +1,4 @@
-import { api } from "./client";
+import api from "./http";
 
 export async function getRegionsLeaderboard() {
   const { data } = await api.get("/regions/leaderboard");

--- a/src/pages/Buddies.jsx
+++ b/src/pages/Buddies.jsx
@@ -5,7 +5,7 @@ import {
   followByUsername,
   unfollow,
   buddiesLeaderboard,
-} from "@/api/buddies";
+} from "../api/buddies";
 
 function clsx(...c) {
   return c.filter(Boolean).join(" ");


### PR DESCRIPTION
## Summary
- add the missing protected routes for the regions leaderboard and buddies pages
- point the buddies and regions API helpers at the shared HTTP client
- fix the buddies page to import the API helper via a working relative path

## Testing
- npm run build *(fails: local vite binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e909eaeda88332aace61b3a6ae59a0