### PR TITLE
ci(cd): use target-based deploy for staging and production

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -126,8 +126,7 @@ jobs:
           checkout_ref "$BACKEND_DIR" "$TARGET_REF"
           checkout_ref "$FRONTEND_DIR" "$TARGET_REF"
 
-          docker compose -f "$BACKEND_DIR/docker-compose.yml" up -d --build
-          docker compose -f "$BACKEND_DIR/docker-compose.yml" ps
+          bash "$BACKEND_DIR/scripts/deploy/deploy-target.sh" "$TARGET_ENV" "$BACKEND_DIR"
 
   rollback:
     name: Rollback (Staging/Production)
@@ -197,5 +196,4 @@ jobs:
           checkout_ref "$BACKEND_DIR" "$TARGET_REF"
           checkout_ref "$FRONTEND_DIR" "$TARGET_REF"
 
-          docker compose -f "$BACKEND_DIR/docker-compose.yml" up -d --build
-          docker compose -f "$BACKEND_DIR/docker-compose.yml" ps
+          bash "$BACKEND_DIR/scripts/deploy/deploy-target.sh" "$TARGET_ENV" "$BACKEND_DIR"

--- a/docs/deploy-github-actions.md
+++ b/docs/deploy-github-actions.md
@@ -10,6 +10,9 @@ Pipeline:
 2. Deploy automatico em `staging` no `push` da `main`.
 3. Deploy manual em `staging` ou `production` via `workflow_dispatch`.
 4. Rollback manual via `workflow_dispatch`.
+5. Publicacao em hostnames locais:
+   - `http://planwriter.staging.test`
+   - `http://planwriter.test`
 
 ## Environments (staging e production)
 
@@ -31,6 +34,20 @@ Exemplo:
 
 Se quiser separar infraestrutura, use caminhos diferentes por ambiente.
 
+## Como o deploy sobe containers separados
+
+O pipeline do frontend usa o script central do backend:
+
+```bash
+$DEPLOY_ROOT/PlanWriter/scripts/deploy/deploy-target.sh staging
+$DEPLOY_ROOT/PlanWriter/scripts/deploy/deploy-target.sh production
+```
+
+Esse script sobe:
+- stack staging (`docker-compose.staging.yml`)
+- stack production (`docker-compose.production.yml`)
+- proxy local (`docker-compose.proxy.yml`)
+
 ## Como rodar deploy manual
 
 No workflow `PlanWriter Frontend Pipeline`, clique em `Run workflow` e escolha:
@@ -40,6 +57,10 @@ No workflow `PlanWriter Frontend Pipeline`, clique em `Run workflow` e escolha:
 - `deploy_ref` (opcional): branch/tag/SHA
 
 Se `deploy_ref` ficar vazio, usa a branch atual do run.
+
+Depois confirme no navegador:
+- `http://planwriter.staging.test`
+- `http://planwriter.test`
 
 ## Como rodar rollback
 
@@ -72,4 +93,13 @@ Opcional via comando (API):
 cd /Users/alessandrosilveira/Documents/Repos/PlanWriter-Frontend
 export GITHUB_TOKEN=seu_token_com_admin_repo
 ./scripts/ci/apply-branch-protection.sh
+```
+
+## /etc/hosts (clientes da rede local)
+
+Em cada máquina cliente:
+
+```text
+192.168.15.182 planwriter.staging.test
+192.168.15.182 planwriter.test
 ```


### PR DESCRIPTION
## Resumo
- ajusta pipeline para usar script de deploy por ambiente no backend
- mantém deploy/rollback por target (staging ou production)
- atualiza docs de deploy com hostnames locais .test

## Dependencia
- requer merge do PR de backend que adiciona scripts/deploy/deploy-target.sh e os compose files de ambiente