### PR TITLE
feat: improve validation UX states and modal feedback

### DIFF
--- a/src/api/validation.jsx
+++ b/src/api/validation.jsx
@@ -10,3 +10,10 @@ export async function previewValidation(eventId, projectId) {
 export async function submitValidation(eventId, projectId, words, source = "manual") {
   await api.post(`/events/${eventId}/validate`, { projectId, words, source });
 }
+
+export async function getValidationStatus(eventId, projectId) {
+  const { data } = await api.get(`/events/${eventId}/validate/status`, {
+    params: { projectId },
+  });
+  return data;
+}

--- a/src/pages/Validate.jsx
+++ b/src/pages/Validate.jsx
@@ -2,7 +2,126 @@ import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getProjects } from "../api/projects";
 import { getActiveEvents } from "../api/events";
-import { previewValidation, submitValidation } from "../api/validation";
+import { getValidationStatus, submitValidation } from "../api/validation";
+import FeedbackModal from "../components/FeedbackModal.jsx";
+
+const DEFAULT_ALLOWED_SOURCES = ["current", "paste", "manual"];
+const MODE_OPTIONS = [
+  { value: "current", label: "Usar total do sistema" },
+  { value: "paste", label: "Colar texto" },
+  { value: "manual", label: "Informar manualmente" },
+];
+const TECHNICAL_ERROR_REGEX =
+  /system\.|exception|stack trace|nullable object|materialization|sql|guid|invalidoperationexception|keynotfoundexception|request failed with status code/i;
+
+function isTechnicalText(value) {
+  return TECHNICAL_ERROR_REGEX.test(String(value ?? ""));
+}
+
+function toFriendlyApiMessage(error, fallbackMessage) {
+  const fallback = fallbackMessage || "Não foi possível concluir esta ação.";
+  const status = Number(error?.response?.status ?? 0);
+
+  if (status === 400) return fallback;
+  if (status === 401) return "Sua sessão expirou. Faça login novamente.";
+  if (status === 403) return "Você não tem permissão para realizar esta ação.";
+  if (status === 404) return "Não encontramos os dados solicitados para validação.";
+  if (status >= 500) return "Estamos com instabilidade no servidor. Tente novamente em instantes.";
+
+  const payload = error?.response?.data;
+  if (typeof payload === "string" && payload.trim().length > 0) {
+    return isTechnicalText(payload) ? fallback : payload;
+  }
+
+  const apiMessage = payload?.message;
+  if (typeof apiMessage === "string" && apiMessage.trim().length > 0) {
+    return isTechnicalText(apiMessage) ? fallback : apiMessage;
+  }
+
+  const apiTitle = payload?.title;
+  if (typeof apiTitle === "string" && apiTitle.trim().length > 0) {
+    return isTechnicalText(apiTitle) ? fallback : apiTitle;
+  }
+
+  const rawMessage = error?.message;
+  if (typeof rawMessage === "string" && rawMessage.trim().length > 0) {
+    return isTechnicalText(rawMessage) ? fallback : rawMessage;
+  }
+
+  return fallback;
+}
+
+function mapSubmitErrorMessage(error) {
+  const fallback = "Não foi possível validar agora. Revise os dados e tente novamente.";
+  const raw =
+    error?.response?.data?.message ||
+    error?.response?.data?.title ||
+    error?.response?.data ||
+    error?.message ||
+    "";
+  const normalized = String(raw).toLowerCase();
+
+  if (normalized.includes("janela")) {
+    return "A janela de validação deste evento está fechada no momento.";
+  }
+
+  if (normalized.includes("menor que a meta") || normalized.includes("faltam")) {
+    return "Sua contagem ainda não atingiu a meta necessária para validar.";
+  }
+
+  if (normalized.includes("fonte de validação")) {
+    return "Este método de validação não está disponível para este evento.";
+  }
+
+  if (normalized.includes("já validado")) {
+    return "Este projeto já foi validado neste evento.";
+  }
+
+  return toFriendlyApiMessage(error, fallback);
+}
+
+function normalizeValidationStatus(payload) {
+  if (!payload || typeof payload !== "object") return null;
+
+  const allowedRaw = payload.allowedSources ?? payload.AllowedSources;
+  const allowedSources = Array.isArray(allowedRaw)
+    ? allowedRaw
+        .map((value) => String(value ?? "").trim().toLowerCase())
+        .filter((value) => DEFAULT_ALLOWED_SOURCES.includes(value))
+    : [];
+
+  const cleanBlockReason = String(payload.blockReason ?? payload.BlockReason ?? "").trim();
+  const blockReason = cleanBlockReason && !isTechnicalText(cleanBlockReason) ? cleanBlockReason : "";
+
+  return {
+    targetWords: Math.max(0, Number(payload.targetWords ?? payload.TargetWords ?? 0)),
+    totalWords: Math.max(0, Number(payload.totalWords ?? payload.TotalWords ?? 0)),
+    isValidated: Boolean(payload.isValidated ?? payload.IsValidated),
+    validatedAtUtc: payload.validatedAtUtc ?? payload.ValidatedAtUtc ?? null,
+    validatedWords:
+      payload.validatedWords ?? payload.ValidatedWords ?? payload.totalWords ?? payload.TotalWords ?? null,
+    validationWindowStartsAtUtc:
+      payload.validationWindowStartsAtUtc ?? payload.ValidationWindowStartsAtUtc ?? null,
+    validationWindowEndsAtUtc:
+      payload.validationWindowEndsAtUtc ?? payload.ValidationWindowEndsAtUtc ?? null,
+    isWithinValidationWindow: Boolean(
+      payload.isWithinValidationWindow ?? payload.IsWithinValidationWindow
+    ),
+    canValidate: Boolean(payload.canValidate ?? payload.CanValidate),
+    blockReason,
+    allowedSources: allowedSources.length ? allowedSources : DEFAULT_ALLOWED_SOURCES,
+  };
+}
+
+function formatDateTime(value) {
+  if (!value) return "--";
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return "--";
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(date);
+}
 
 function countWordsStrict(text) {
   if (!text) return 0;
@@ -22,16 +141,27 @@ export default function Validate() {
   const [paste, setPaste] = useState("");
   const [manual, setManual] = useState(0);
 
-  const [target, setTarget] = useState(0);
-  const [currentTotal, setCurrentTotal] = useState(0);
-
+  const [statusData, setStatusData] = useState(null);
+  const [loadingStatus, setLoadingStatus] = useState(false);
   const [err, setErr] = useState("");
   const [saving, setSaving] = useState(false);
+  const [feedback, setFeedback] = useState({
+    open: false,
+    type: "info",
+    title: "",
+    message: "",
+    primaryLabel: "OK",
+    onPrimary: null,
+  });
 
   useEffect(() => {
+    let cancelled = false;
+
     (async () => {
+      setErr("");
       try {
         const [ps, evs] = await Promise.all([getProjects(), getActiveEvents()]);
+        if (cancelled) return;
         const list = Array.isArray(ps) ? ps : [];
         const eventsList = Array.isArray(evs) && evs.length ? evs : [];
         setProjects(list);
@@ -39,45 +169,185 @@ export default function Validate() {
         if (list[0]) setProjectId(list[0].id ?? list[0].projectId);
         if (eventsList[0]) setEventId(eventsList[0].id ?? eventsList[0].Id);
       } catch (e) {
-        setErr(e?.response?.data?.message || e?.message || "Falha ao carregar dados.");
+        if (cancelled) return;
+        setErr(toFriendlyApiMessage(e, "Falha ao carregar dados para validação."));
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  // preview do servidor (meta e total apurado)
   useEffect(() => {
-    if (!projectId || !eventId) return;
+    if (!projectId || !eventId) {
+      setStatusData(null);
+      return;
+    }
+
+    let cancelled = false;
+
     (async () => {
+      setLoadingStatus(true);
+      setErr("");
       try {
-        const p = await previewValidation(eventId, projectId);
-        setTarget(Number(p.target) || 0);
-        setCurrentTotal(Number(p.total) || 0);
+        const payload = await getValidationStatus(eventId, projectId);
+        if (cancelled) return;
+        setStatusData(normalizeValidationStatus(payload));
       } catch (e) {
-        setErr(e?.response?.data?.message || e?.message || "Falha ao obter prévia.");
+        if (cancelled) return;
+        setStatusData(null);
+        setErr(toFriendlyApiMessage(e, "Não foi possível consultar seu status de validação."));
+      } finally {
+        if (!cancelled) setLoadingStatus(false);
       }
     })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [projectId, eventId]);
 
-  // total escolhido conforme modo
+  const allowedSources = statusData?.allowedSources ?? DEFAULT_ALLOWED_SOURCES;
+
+  useEffect(() => {
+    if (!allowedSources.includes(mode)) {
+      setMode(allowedSources[0] ?? "current");
+    }
+  }, [allowedSources, mode]);
+
+  const target = statusData?.targetWords ?? 0;
+  const currentTotal = statusData?.totalWords ?? 0;
+
   const chosenTotal = useMemo(() => {
     if (mode === "current") return currentTotal;
     if (mode === "paste") return countWordsStrict(paste);
     return Math.max(0, Number(manual) || 0);
   }, [mode, currentTotal, paste, manual]);
 
-  const canSubmit = projectId && eventId && chosenTotal >= target;
+  const isModeAllowed = allowedSources.includes(mode);
+  const missingWords = Math.max(0, target - chosenTotal);
+
+  const statusView = useMemo(() => {
+    if (!projectId || !eventId) {
+      return {
+        key: "pendente",
+        label: "pendente",
+        type: "info",
+        badgeClass: "bg-slate-100 text-slate-700",
+        message: "Selecione um projeto e um evento para continuar.",
+      };
+    }
+
+    if (!statusData) {
+      return {
+        key: "pendente",
+        label: "pendente",
+        type: "info",
+        badgeClass: "bg-slate-100 text-slate-700",
+        message: loadingStatus
+          ? "Consultando seu status de validação…"
+          : "Não foi possível carregar o status neste momento.",
+      };
+    }
+
+    if (statusData.isValidated) {
+      return {
+        key: "ja-validado",
+        label: "já validado",
+        type: "success",
+        badgeClass: "bg-green-100 text-green-700",
+        message: `Projeto validado em ${formatDateTime(statusData.validatedAtUtc)}.`,
+      };
+    }
+
+    if (!statusData.isWithinValidationWindow) {
+      return {
+        key: "fora-janela",
+        label: "fora da janela",
+        type: "warning",
+        badgeClass: "bg-amber-100 text-amber-800",
+        message: "A validação deste evento está fora da janela permitida.",
+      };
+    }
+
+    if (!isModeAllowed) {
+      return {
+        key: "pendente",
+        label: "pendente",
+        type: "warning",
+        badgeClass: "bg-amber-100 text-amber-800",
+        message: "Esse método de validação não é aceito neste evento.",
+      };
+    }
+
+    if (target > 0 && chosenTotal >= target) {
+      return {
+        key: "apto",
+        label: "apto",
+        type: "success",
+        badgeClass: "bg-green-100 text-green-700",
+        message: "Tudo pronto. Você já pode validar este projeto.",
+      };
+    }
+
+    return {
+      key: "pendente",
+      label: "pendente",
+      type: "info",
+      badgeClass: "bg-slate-100 text-slate-700",
+      message:
+        statusData.blockReason ||
+        `Ainda faltam ${missingWords.toLocaleString("pt-BR")} palavras para atingir a meta.`,
+    };
+  }, [projectId, eventId, statusData, loadingStatus, isModeAllowed, target, chosenTotal, missingWords]);
+
+  const canSubmit = statusView.key === "apto" && !saving;
+
+  const closeFeedback = () => {
+    setFeedback((prev) => ({ ...prev, open: false, onPrimary: null }));
+  };
 
   const submit = async () => {
-    setSaving(true); setErr("");
+    setSaving(true);
+    setErr("");
     try {
       await submitValidation(eventId, projectId, chosenTotal, mode);
-      navigate(`/u/me`); // ou onde preferir; se tiver slug, pode navegar para perfil público
+      setFeedback({
+        open: true,
+        type: "success",
+        title: "Validação concluída",
+        message: `Projeto validado com ${chosenTotal.toLocaleString("pt-BR")} palavras.`,
+        primaryLabel: "OK",
+        onPrimary: () => navigate("/winner"),
+      });
     } catch (e) {
-      setErr(e?.response?.data?.message || e?.message || "Não foi possível validar.");
+      setFeedback({
+        open: true,
+        type: "error",
+        title: "Não foi possível validar",
+        message: mapSubmitErrorMessage(e),
+        primaryLabel: "OK",
+        onPrimary: null,
+      });
     } finally {
       setSaving(false);
     }
   };
+
+  const windowStarts = formatDateTime(statusData?.validationWindowStartsAtUtc);
+  const windowEnds = formatDateTime(statusData?.validationWindowEndsAtUtc);
+  const allowedSourceLabels = MODE_OPTIONS.filter((option) => allowedSources.includes(option.value)).map(
+    (option) => option.label
+  );
+  const ctaLabel =
+    statusView.key === "apto"
+      ? "Validar agora"
+      : statusView.key === "ja-validado"
+        ? "Já validado"
+        : statusView.key === "fora-janela"
+          ? "Fora da janela"
+          : "Ainda não apto";
 
   return (
     <div className="container py-6 space-y-4">
@@ -114,6 +384,22 @@ export default function Validate() {
           </label>
         </div>
 
+        <div className="mt-3 rounded-xl border border-[var(--line)] bg-[var(--surface)] px-4 py-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-sm font-semibold">Status da validação</p>
+            <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${statusView.badgeClass}`}>
+              {statusView.label}
+            </span>
+          </div>
+          <p className="mt-2 text-sm text-[var(--ink-soft)]">{statusView.message}</p>
+          <p className="mt-1 text-xs text-[var(--ink-soft)]">
+            Janela: {windowStarts} até {windowEnds}
+          </p>
+          <p className="mt-1 text-xs text-[var(--ink-soft)]">
+            Métodos permitidos: {allowedSourceLabels.length ? allowedSourceLabels.join(" • ") : "Não informado"}
+          </p>
+        </div>
+
         <div className="mt-3 grid grid-cols-2 md:grid-cols-4 gap-3">
           <div className="kpi">
             <div className="label">Meta do evento</div>
@@ -131,28 +417,34 @@ export default function Validate() {
             <div className="hint">{mode === "current" ? "do sistema" : mode === "paste" ? "do texto colado" : "manual"}</div>
           </div>
           <div className="kpi">
-            <div className="label">{chosenTotal >= target ? "Status" : "Faltam"}</div>
-            <div className={`value ${chosenTotal >= target ? "text-green-700 dark:text-green-400" : ""}`}>
-              {chosenTotal >= target ? "OK ✅" : (target - chosenTotal).toLocaleString("pt-BR")}
+            <div className="label">{statusView.key === "apto" ? "Status" : "Faltam"}</div>
+            <div className={`value ${statusView.key === "apto" ? "text-green-700 dark:text-green-400" : ""}`}>
+              {statusView.key === "apto" ? "OK ✅" : missingWords.toLocaleString("pt-BR")}
             </div>
-            <div className="hint">{chosenTotal >= target ? "pronto para validar" : "palavras"}</div>
+            <div className="hint">{statusView.key === "apto" ? "pronto para validar" : "palavras"}</div>
           </div>
         </div>
 
         <div className="mt-4">
           <div className="flex items-center gap-2">
-            <label className={`button ${mode==="current"?"ghost":""}`}>
-              <input type="radio" className="sr-only" checked={mode==="current"} onChange={()=>setMode("current")} />
-              Usar total do sistema
-            </label>
-            <label className={`button ${mode==="paste"?"ghost":""}`}>
-              <input type="radio" className="sr-only" checked={mode==="paste"} onChange={()=>setMode("paste")} />
-              Colar texto
-            </label>
-            <label className={`button ${mode==="manual"?"ghost":""}`}>
-              <input type="radio" className="sr-only" checked={mode==="manual"} onChange={()=>setMode("manual")} />
-              Informar manualmente
-            </label>
+            {MODE_OPTIONS.map((option) => {
+              const disabled = !allowedSources.includes(option.value);
+              return (
+                <label
+                  key={option.value}
+                  className={`button ${mode === option.value ? "ghost" : ""} ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
+                >
+                  <input
+                    type="radio"
+                    className="sr-only"
+                    checked={mode === option.value}
+                    onChange={() => setMode(option.value)}
+                    disabled={disabled}
+                  />
+                  {option.label}
+                </label>
+              );
+            })}
           </div>
 
           {mode === "paste" && (
@@ -185,11 +477,25 @@ export default function Validate() {
 
         <div className="mt-4 flex items-center gap-2">
           <button className="button" onClick={() => navigate(-1)}>Cancelar</button>
-          <button className="btn-primary" onClick={submit} disabled={!canSubmit || saving}>
-            {saving ? "Validando…" : "Validar e comemorar 🎉"}
+          <button className="btn-primary" onClick={submit} disabled={!canSubmit}>
+            {saving ? "Validando…" : ctaLabel}
           </button>
         </div>
       </section>
+
+      <FeedbackModal
+        open={feedback.open}
+        type={feedback.type}
+        title={feedback.title}
+        message={feedback.message}
+        primaryLabel={feedback.primaryLabel}
+        onPrimary={() => {
+          const callback = feedback.onPrimary;
+          closeFeedback();
+          callback?.();
+        }}
+        onClose={closeFeedback}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Resumo
- Implementa fluxo de validação orientado por status em `Validate.jsx`
- Exibe estados explícitos: `apto`, `fora da janela`, `já validado` e `pendente`
- Ajusta CTA conforme estado atual
- Padroniza retorno final em `FeedbackModal` com mensagens amigáveis
- Remove exposição de mensagens técnicas de backend para o usuário

## Alterações principais
- `src/api/validation.jsx`
  - adiciona `getValidationStatus(eventId, projectId)`
- `src/pages/Validate.jsx`
  - consome `/validate/status`
  - calcula estado visual e CTA com base no status
  - bloqueia métodos de validação não permitidos pelo evento
  - sanitiza mensagens de erro técnicas
  - usa modal para sucesso/erro na validação

## Validação
- `npm run build`

Closes #26
