### PR TITLE
fix: keep Events progress consistent with dashboard

### DIFF
--- a/src/components/EventProgressCard.jsx
+++ b/src/components/EventProgressCard.jsx
@@ -4,6 +4,7 @@ import {
   getMyEvents,
   getEventProjectProgress,
 } from "../api/events";
+import { normalizeEventProjectProgress } from "../utils/eventProgress";
 
 export default function EventProgressCard({ eventId, projectId }) {
   const [loading, setLoading] = useState(true);
@@ -86,14 +87,12 @@ export default function EventProgressCard({ eventId, projectId }) {
 
   if (!progress) return null;
 
-  // 🔥 CAMPOS REAIS DO BACKEND
-  const eventName = progress.name ?? "Evento";
-  const current = Number(progress.totalWrittenInEvent ?? 0);
-  const target = Math.max(1, Number(progress.targetWords ?? 1));
-  const percent =
-    progress.percent != null
-      ? Math.min(100, Math.round(progress.percent))
-      : Math.min(100, Math.round((current / target) * 100));
+  const normalizedProgress = normalizeEventProjectProgress(progress);
+  const eventName = normalizedProgress.eventName;
+  const current = normalizedProgress.totalWrittenInEvent;
+  const target = normalizedProgress.targetWords;
+  const percent = normalizedProgress.percent;
+  const remaining = normalizedProgress.remainingWords;
 
   return (
     <div className="card">
@@ -113,9 +112,7 @@ export default function EventProgressCard({ eventId, projectId }) {
 
       <div className="flex justify-between text-sm text-muted">
         <span>{percent}% concluído</span>
-        {progress.daysLeft != null && (
-          <span>{progress.daysLeft} dias restantes</span>
-        )}
+        {remaining > 0 ? <span>{remaining.toLocaleString("pt-BR")} restantes</span> : <span>Meta concluída</span>}
       </div>
     </div>
   );

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
   getEventById,
@@ -9,6 +9,7 @@ import {
 } from "../api/events";
 import { useAuth } from "../context/AuthContext";
 import WordWarPanel from "../components/WordWarPanel.jsx";
+import { normalizeEventProjectProgress } from "../utils/eventProgress";
 
 export default function EventDetails() {
   const { user } = useAuth();
@@ -26,8 +27,18 @@ export default function EventDetails() {
   const formatDate = (value) =>
     value ? new Date(value).toLocaleDateString("pt-BR") : "—";
 
-  const percent = progress?.percent ?? 0;
-  const isCompleted = progress?.percent >= 100;
+  const normalizedProgress = useMemo(
+    () =>
+      progress
+        ? normalizeEventProjectProgress(progress, {
+            fallbackTargetWords: event?.defaultTargetWords,
+          })
+        : null,
+    [progress, event?.defaultTargetWords]
+  );
+
+  const percent = normalizedProgress?.percent ?? 0;
+  const isCompleted = normalizedProgress?.won ?? false;
 
   useEffect(() => {
     let mounted = true;
@@ -139,10 +150,11 @@ export default function EventDetails() {
             <p className="text-sm text-gray-500">
               Você ainda não participa deste evento.
             </p>
-          ) : progress ? (
+          ) : normalizedProgress ? (
             <>
               <p className="mb-2 text-sm">
-                {progress.totalWrittenInEvent} / {progress.targetWords} palavras
+                {normalizedProgress.totalWrittenInEvent.toLocaleString("pt-BR")} /{" "}
+                {normalizedProgress.targetWords.toLocaleString("pt-BR")} palavras
               </p>
 
               <div className="h-2 bg-[#e6dccb] rounded-full overflow-hidden mb-3">
@@ -155,7 +167,7 @@ export default function EventDetails() {
               <p className="text-sm text-gray-600">
                 {isCompleted
                   ? "Meta concluída 🎉"
-                  : `${progress.percent}% concluído • ${progress.remaining} palavras restantes`}
+                  : `${percent}% concluído • ${normalizedProgress.remainingWords.toLocaleString("pt-BR")} palavras restantes`}
               </p>
             </>
           ) : (

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -4,17 +4,43 @@ import { getProjects } from "../api/projects";
 import { getActiveEvents, getMyEvents, joinEvent } from "../api/events";
 import JoinEventModal from "../components/JoinEventModal";
 import FeedbackModal from "../components/FeedbackModal.jsx";
+import {
+  normalizeEntityId,
+  normalizeMyEventProgress,
+  resolveTargetWords,
+} from "../utils/eventProgress";
 
 function getApiErrorMessage(error) {
+  const fallback = "Não foi possível concluir sua participação agora. Tente novamente.";
+  const status = Number(error?.response?.status ?? 0);
+  if (status === 400) return fallback;
+  if (status === 401) return "Sua sessão expirou. Faça login novamente.";
+  if (status === 403) return "Você não tem permissão para participar deste evento.";
+  if (status === 404) return "Evento ou projeto não encontrado.";
+  if (status >= 500) return "Estamos com instabilidade no servidor. Tente novamente em instantes.";
+
   const data = error?.response?.data;
+  const isTechnical = (value) =>
+    /system\.|exception|stack trace|nullable object|materialization|sql|guid|invalidoperationexception|keynotfoundexception|request failed with status code/i.test(
+      String(value ?? "")
+    );
 
   if (typeof data === "string" && data.trim().length > 0) {
-    return data;
+    return isTechnical(data) ? fallback : data;
   }
 
-  if (data?.message) return data.message;
-  if (data?.title) return data.title;
-  return error?.message || "Não foi possível concluir sua participação.";
+  if (data?.message) {
+    return isTechnical(data.message) ? fallback : data.message;
+  }
+  if (data?.title) {
+    return isTechnical(data.title) ? fallback : data.title;
+  }
+
+  if (error?.message) {
+    return isTechnical(error.message) ? fallback : error.message;
+  }
+
+  return fallback;
 }
 
 export default function Events() {
@@ -39,9 +65,30 @@ export default function Events() {
     onPrimary: null,
   });
 
+  const activeEventsById = useMemo(() => {
+    const map = new Map();
+    for (const eventItem of activeEvents) {
+      const key = normalizeEntityId(eventItem?.id ?? eventItem?.Id);
+      if (!key) continue;
+      map.set(key, eventItem);
+    }
+    return map;
+  }, [activeEvents]);
+
+  const normalizedMyEvents = useMemo(() => {
+    return myEvents
+      .map((entry) => {
+        const eventIdKey = normalizeEntityId(entry?.eventId ?? entry?.EventId ?? entry?.id ?? entry?.Id);
+        const activeEvent = activeEventsById.get(eventIdKey);
+        const fallbackTargetWords = activeEvent?.defaultTargetWords ?? activeEvent?.DefaultTargetWords;
+        return normalizeMyEventProgress(entry, { fallbackTargetWords });
+      })
+      .filter((entry) => Boolean(entry.eventId));
+  }, [myEvents, activeEventsById]);
+
   const myEventIds = useMemo(
-    () => new Set(myEvents.map((entry) => entry.eventId)),
-    [myEvents]
+    () => new Set(normalizedMyEvents.map((entry) => normalizeEntityId(entry.eventId))),
+    [normalizedMyEvents]
   );
 
   useEffect(() => {
@@ -111,7 +158,7 @@ export default function Events() {
       setJoining(true);
 
       await joinEvent({
-        eventId: joinModalEvent.id,
+        eventId: joinModalEvent.id ?? joinModalEvent.Id,
         projectId,
       });
 
@@ -123,10 +170,10 @@ export default function Events() {
         open: true,
         type: "success",
         title: "Participação confirmada",
-        message: `Você entrou no evento "${joinModalEvent.name}".`,
+        message: `Você entrou no evento "${joinModalEvent.name ?? joinModalEvent.Name}".`,
         primaryLabel: "Ver detalhes",
         onPrimary: () => {
-          const targetEventId = joinModalEvent.id;
+          const targetEventId = joinModalEvent.id ?? joinModalEvent.Id;
           setFeedback((prev) => ({ ...prev, open: false }));
           navigate(`/events/${targetEventId}`);
         },
@@ -164,27 +211,33 @@ export default function Events() {
             <div className="space-y-4">
               {activeEvents.map((ev) => (
                 <div
-                  key={ev.id}
+                  key={ev.id ?? ev.Id}
                   className="bg-[#fffaf2] border border-[#eadfce] rounded-xl p-6 flex justify-between items-center"
                 >
                   <div>
                     <p className="text-sm uppercase tracking-wide text-gray-500 mb-1">Evento</p>
 
-                    <h3 className="text-xl font-serif font-semibold">{ev.name}</h3>
+                    <h3 className="text-xl font-serif font-semibold">{ev.name ?? ev.Name}</h3>
 
                     <p className="text-sm text-gray-600 mt-1">
                       {formatDate(ev.startsAtUtc)} → {formatDate(ev.endsAtUtc)}
                     </p>
 
                     <p className="text-sm text-gray-500 mt-1">
-                      Meta: {ev.defaultTargetWords} palavras
+                      Meta:{" "}
+                      {resolveTargetWords(
+                        ev.defaultTargetWords ?? ev.DefaultTargetWords,
+                        null,
+                        null
+                      ).toLocaleString("pt-BR")}{" "}
+                      palavras
                     </p>
                   </div>
 
-                  {myEventIds.has(ev.id) ? (
+                  {myEventIds.has(normalizeEntityId(ev.id ?? ev.Id)) ? (
                     <button
                       type="button"
-                      onClick={() => navigate(`/events/${ev.id}`)}
+                      onClick={() => navigate(`/events/${ev.id ?? ev.Id}`)}
                       className="px-5 py-2 border rounded-lg"
                     >
                       Detalhes
@@ -209,33 +262,37 @@ export default function Events() {
         <section>
           <h2 className="text-2xl font-serif font-semibold mb-4">Meus eventos</h2>
 
-          {myEvents.length === 0 ? (
+          {normalizedMyEvents.length === 0 ? (
             <p className="text-sm text-gray-500">Você ainda não participa de nenhum evento.</p>
           ) : (
             <div className="space-y-4">
-              {myEvents.map((ev) => (
+              {normalizedMyEvents.map((ev) => (
                 <div
-                  key={ev.eventId}
+                  key={`${ev.eventId}-${ev.projectId ?? "no-project"}`}
                   className="bg-[#fffaf2] border border-[#eadfce] rounded-xl p-6 shadow-sm"
                 >
                   <p className="text-sm uppercase tracking-wide text-gray-500 mb-1">Evento</p>
 
                   <h3 className="text-2xl font-serif font-semibold">{ev.eventName}</h3>
 
-                  <p className="text-sm text-gray-600 mb-3">
-                    Projeto: {ev.projectTitle ?? "Participação individual"}
+                  <p className="text-sm text-gray-600">
+                    Projeto: {ev.projectTitle}
+                  </p>
+
+                  <p className="text-sm text-gray-700 mb-2">
+                    {ev.totalWrittenInEvent.toLocaleString("pt-BR")} / {ev.targetWords.toLocaleString("pt-BR")} palavras
                   </p>
 
                   <div className="h-2 bg-[#e6dccb] rounded-full overflow-hidden mb-3">
                     <div
                       className="h-2 bg-[#8b6b4f]"
-                      style={{ width: `${Math.min(ev.percent, 100)}%` }}
+                      style={{ width: `${ev.percent}%` }}
                     />
                   </div>
 
                   <div className="flex justify-between items-center">
                     <span className="text-sm text-gray-600">
-                      {Math.min(ev.percent, 100)}% concluído
+                      {ev.percent}% concluído
                     </span>
 
                     <button

--- a/src/utils/eventProgress.js
+++ b/src/utils/eventProgress.js
@@ -1,0 +1,73 @@
+const DEFAULT_TARGET_WORDS = 50000;
+
+function toSafeNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function normalizeEntityId(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+export function resolveTargetWords(targetWords, eventDefaultTargetWords, fallbackTargetWords) {
+  const candidates = [targetWords, eventDefaultTargetWords, fallbackTargetWords, DEFAULT_TARGET_WORDS];
+  for (const candidate of candidates) {
+    const parsed = toSafeNumber(candidate);
+    if (parsed > 0) return Math.round(parsed);
+  }
+  return DEFAULT_TARGET_WORDS;
+}
+
+export function calculateEventProgressMetrics({
+  totalWrittenInEvent,
+  targetWords,
+  eventDefaultTargetWords,
+  fallbackTargetWords,
+}) {
+  const safeTotal = Math.max(0, Math.round(toSafeNumber(totalWrittenInEvent)));
+  const safeTarget = resolveTargetWords(targetWords, eventDefaultTargetWords, fallbackTargetWords);
+  const percent = Math.min(100, Math.max(0, Math.round((safeTotal * 100) / safeTarget)));
+  const remainingWords = Math.max(0, safeTarget - safeTotal);
+
+  return {
+    targetWords: safeTarget,
+    totalWrittenInEvent: safeTotal,
+    percent,
+    remainingWords,
+    won: safeTotal >= safeTarget,
+  };
+}
+
+export function normalizeMyEventProgress(eventItem, options = {}) {
+  const eventId = eventItem?.eventId ?? eventItem?.EventId ?? eventItem?.id ?? eventItem?.Id ?? "";
+  const projectId = eventItem?.projectId ?? eventItem?.ProjectId ?? eventItem?.project?.id ?? null;
+  const metrics = calculateEventProgressMetrics({
+    totalWrittenInEvent: eventItem?.totalWrittenInEvent ?? eventItem?.TotalWrittenInEvent,
+    targetWords: eventItem?.targetWords ?? eventItem?.TargetWords,
+    eventDefaultTargetWords: eventItem?.eventDefaultTargetWords ?? eventItem?.EventDefaultTargetWords,
+    fallbackTargetWords: options.fallbackTargetWords,
+  });
+
+  return {
+    eventId,
+    eventName: eventItem?.eventName ?? eventItem?.EventName ?? "Evento",
+    projectId,
+    projectTitle: eventItem?.projectTitle ?? eventItem?.ProjectTitle ?? "Participação individual",
+    ...metrics,
+  };
+}
+
+export function normalizeEventProjectProgress(progress, options = {}) {
+  const metrics = calculateEventProgressMetrics({
+    totalWrittenInEvent: progress?.totalWrittenInEvent ?? progress?.TotalWrittenInEvent,
+    targetWords: progress?.targetWords ?? progress?.TargetWords,
+    eventDefaultTargetWords: progress?.eventDefaultTargetWords ?? progress?.EventDefaultTargetWords,
+    fallbackTargetWords: options.fallbackTargetWords,
+  });
+
+  return {
+    ...progress,
+    eventName: progress?.name ?? progress?.eventName ?? progress?.EventName ?? "Evento",
+    ...metrics,
+  };
+}


### PR DESCRIPTION
## Resumo
- Corrige divergencia de `current/target/percent` na secao **Meus eventos** da tela Events.
- Unifica o calculo de progresso entre Events, Dashboard e EventDetails.
- Aplica fallback seguro para meta (`targetWords`) para evitar `x / 0 palavras`.
- Sanitiza mensagens de erro para nao exibir texto tecnico do backend ao usuario.

## O que foi alterado
- Adicionado util comum de progresso de evento:
  - `src/utils/eventProgress.js`
- Aplicado em:
  - `src/pages/Events.jsx`
  - `src/components/EventProgressCard.jsx`
  - `src/pages/EventDetails.jsx`

## Regras aplicadas
- `targetWords`: usa meta do projeto; se ausente/invalida, usa default do evento; se ainda ausente, usa `50000`.
- `percent`: sempre calculado de forma uniforme com base em `totalWrittenInEvent / targetWords`.
- `remaining`: calculado como `max(0, target - total)`.

## Validacao
- `npm run build`

Closes #27
