### PR TITLE
feat: standardize event progress card across screens

### DIFF
--- a/src/components/EventProgressCard.jsx
+++ b/src/components/EventProgressCard.jsx
@@ -1,15 +1,28 @@
 // src/components/EventProgressCard.jsx
+import { useMemo } from "react";
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   getMyEvents,
   getEventProjectProgress,
 } from "../api/events";
-import { normalizeEventProjectProgress } from "../utils/eventProgress";
+import {
+  normalizeEntityId,
+  normalizeEventProjectProgress,
+} from "../utils/eventProgress";
+import EventProgressStatusCard from "./EventProgressStatusCard.jsx";
 
-export default function EventProgressCard({ eventId, projectId }) {
+export default function EventProgressCard({
+  eventId,
+  projectId,
+  projectTitle,
+  showDetailsAction = true,
+}) {
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [progress, setProgress] = useState(null);
+  const [resolvedEventId, setResolvedEventId] = useState("");
 
   useEffect(() => {
     let alive = true;
@@ -18,6 +31,7 @@ export default function EventProgressCard({ eventId, projectId }) {
       setLoading(true);
       setError("");
       setProgress(null);
+      setResolvedEventId("");
 
       try {
         let resolvedEventId = eventId;
@@ -26,11 +40,12 @@ export default function EventProgressCard({ eventId, projectId }) {
         // 🔍 Resolve eventId automaticamente se só veio projectId
         if (!resolvedEventId && resolvedProjectId) {
           const myEvents = await getMyEvents();
+          const normalizedProjectId = normalizeEntityId(resolvedProjectId);
           const found = (myEvents || []).find(
-            (e) => e.projectId === resolvedProjectId
+            (entry) => normalizeEntityId(entry?.projectId ?? entry?.ProjectId) === normalizedProjectId
           );
           if (found) {
-            resolvedEventId = found.eventId;
+            resolvedEventId = found.eventId ?? found.EventId;
           }
         }
 
@@ -50,6 +65,7 @@ export default function EventProgressCard({ eventId, projectId }) {
 
         if (!alive) return;
 
+        setResolvedEventId(resolvedEventId);
         setProgress(data);
       } catch {
         if (alive) {
@@ -67,10 +83,20 @@ export default function EventProgressCard({ eventId, projectId }) {
 
   /* ===================== RENDER ===================== */
 
+  const normalizedProgress = useMemo(() => {
+    if (!progress) return null;
+    return normalizeEventProjectProgress(progress);
+  }, [progress]);
+
+  const detailsHandler = useMemo(() => {
+    if (!showDetailsAction || !resolvedEventId) return null;
+    return () => navigate(`/events/${resolvedEventId}`);
+  }, [showDetailsAction, resolvedEventId, navigate]);
+
   if (loading) {
     return (
-      <div className="card">
-        <h3 className="font-semibold mb-2">Progresso do Evento</h3>
+      <div className="bg-[#fffaf2] border border-[#eadfce] rounded-xl p-6 shadow-sm">
+        <h3 className="font-semibold mb-2">Evento</h3>
         <p className="text-sm text-muted">Carregando…</p>
       </div>
     );
@@ -78,42 +104,26 @@ export default function EventProgressCard({ eventId, projectId }) {
 
   if (error) {
     return (
-      <div className="card">
-        <h3 className="font-semibold mb-2">Progresso do Evento</h3>
+      <div className="bg-[#fffaf2] border border-[#eadfce] rounded-xl p-6 shadow-sm">
+        <h3 className="font-semibold mb-2">Evento</h3>
         <p className="text-sm text-red-600">{error}</p>
       </div>
     );
   }
 
-  if (!progress) return null;
-
-  const normalizedProgress = normalizeEventProjectProgress(progress);
-  const eventName = normalizedProgress.eventName;
-  const current = normalizedProgress.totalWrittenInEvent;
-  const target = normalizedProgress.targetWords;
-  const percent = normalizedProgress.percent;
-  const remaining = normalizedProgress.remainingWords;
+  if (!normalizedProgress) return null;
 
   return (
-    <div className="card">
-      <h3 className="font-semibold mb-1">{eventName}</h3>
-
-      <p className="text-sm text-muted mb-2">
-        {current.toLocaleString("pt-BR")} /{" "}
-        {target.toLocaleString("pt-BR")} palavras
-      </p>
-
-      <div className="h-2 bg-black/10 rounded overflow-hidden mb-2">
-        <div
-          className="h-full bg-indigo-600"
-          style={{ width: `${percent}%` }}
-        />
-      </div>
-
-      <div className="flex justify-between text-sm text-muted">
-        <span>{percent}% concluído</span>
-        {remaining > 0 ? <span>{remaining.toLocaleString("pt-BR")} restantes</span> : <span>Meta concluída</span>}
-      </div>
-    </div>
+    <EventProgressStatusCard
+      eventName={normalizedProgress.eventName}
+      projectTitle={projectTitle}
+      totalWords={normalizedProgress.totalWrittenInEvent}
+      targetWords={normalizedProgress.targetWords}
+      percent={normalizedProgress.percent}
+      remainingWords={normalizedProgress.remainingWords}
+      won={normalizedProgress.won}
+      onAction={detailsHandler || undefined}
+      actionLabel="Detalhes"
+    />
   );
 }

--- a/src/components/EventProgressStatusCard.jsx
+++ b/src/components/EventProgressStatusCard.jsx
@@ -1,0 +1,79 @@
+function formatWords(value) {
+  const parsed = Number(value);
+  const safe = Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
+  return safe.toLocaleString("pt-BR");
+}
+
+export default function EventProgressStatusCard({
+  eventName,
+  projectTitle,
+  totalWords,
+  targetWords,
+  percent,
+  remainingWords,
+  won = false,
+  onAction,
+  actionLabel = "Detalhes",
+  className = "",
+}) {
+  const safePercent = Math.min(100, Math.max(0, Math.round(Number(percent ?? 0))));
+  const safeRemainingWords = Math.max(0, Math.round(Number(remainingWords ?? 0)));
+  const isCompleted = Boolean(won) || safePercent >= 100;
+  const progressClass = isCompleted
+    ? "bg-gradient-to-r from-emerald-400 via-green-500 to-emerald-600"
+    : "bg-[#8b6b4f]";
+
+  return (
+    <div className={`bg-[#fffaf2] border border-[#eadfce] rounded-xl p-6 shadow-sm ${className}`.trim()}>
+      <p className="text-sm uppercase tracking-wide text-gray-500 mb-1">Evento</p>
+
+      <div className="flex items-center gap-2">
+        <h3 className="text-2xl font-serif font-semibold">{eventName || "Evento"}</h3>
+        {isCompleted && (
+          <span
+            className="inline-flex items-center justify-center h-6 w-6 rounded-full bg-emerald-100 text-emerald-700 text-sm font-bold"
+            aria-label="Evento concluído"
+            title="Evento concluído"
+          >
+            ✓
+          </span>
+        )}
+      </div>
+
+      <p className="text-sm text-gray-600 mt-1">Projeto: {projectTitle || "Participação individual"}</p>
+
+      <p className="text-sm text-gray-700 mt-2 mb-2">
+        {formatWords(totalWords)} / {formatWords(targetWords)} palavras
+      </p>
+
+      <div className="h-2 bg-[#e6dccb] rounded-full overflow-hidden mb-3">
+        <div
+          className={`h-2 ${progressClass}`}
+          style={{ width: `${safePercent}%` }}
+        />
+      </div>
+
+      <div className="flex justify-between items-center gap-4">
+        <span className={`text-sm ${isCompleted ? "text-emerald-700 font-medium" : "text-gray-600"}`}>
+          {safePercent}% concluído
+        </span>
+
+        {onAction ? (
+          <button
+            type="button"
+            onClick={onAction}
+            className="px-4 py-2 border rounded-lg"
+          >
+            {actionLabel}
+          </button>
+        ) : (
+          <span className="text-sm text-gray-600">
+            {isCompleted
+              ? "Meta concluída"
+              : `${formatWords(safeRemainingWords)} palavras restantes`}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -368,7 +368,9 @@ export default function Dashboard() {
                 {myEvents.map((ev) => (
                   <EventProgressCard
                     key={ev.eventId ?? ev.id}
+                    eventId={ev.eventId ?? ev.id}
                     projectId={ev.projectId ?? ev.project?.id}
+                    projectTitle={ev.projectTitle ?? ev.project?.title}
                   />
                 ))}
               </div>

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -9,6 +9,7 @@ import {
 } from "../api/events";
 import { useAuth } from "../context/AuthContext";
 import WordWarPanel from "../components/WordWarPanel.jsx";
+import EventProgressStatusCard from "../components/EventProgressStatusCard.jsx";
 import { normalizeEventProjectProgress } from "../utils/eventProgress";
 
 export default function EventDetails() {
@@ -143,7 +144,7 @@ export default function EventDetails() {
 
         <WordWarPanel eventId={eventId} eventName={event.name} />
 
-        <div className="bg-[#fffaf2] border border-[#eadfce] rounded-xl p-6">
+        <section>
           <h2 className="text-xl font-serif font-semibold mb-3">Seu progresso</h2>
 
           {!myEvent ? (
@@ -151,29 +152,19 @@ export default function EventDetails() {
               Você ainda não participa deste evento.
             </p>
           ) : normalizedProgress ? (
-            <>
-              <p className="mb-2 text-sm">
-                {normalizedProgress.totalWrittenInEvent.toLocaleString("pt-BR")} /{" "}
-                {normalizedProgress.targetWords.toLocaleString("pt-BR")} palavras
-              </p>
-
-              <div className="h-2 bg-[#e6dccb] rounded-full overflow-hidden mb-3">
-                <div
-                  className="h-2 bg-[#8b6b4f]"
-                  style={{ width: `${Math.min(percent, 100)}%` }}
-                />
-              </div>
-
-              <p className="text-sm text-gray-600">
-                {isCompleted
-                  ? "Meta concluída 🎉"
-                  : `${percent}% concluído • ${normalizedProgress.remainingWords.toLocaleString("pt-BR")} palavras restantes`}
-              </p>
-            </>
+            <EventProgressStatusCard
+              eventName={event.name}
+              projectTitle={myEvent.projectTitle}
+              totalWords={normalizedProgress.totalWrittenInEvent}
+              targetWords={normalizedProgress.targetWords}
+              percent={percent}
+              remainingWords={normalizedProgress.remainingWords}
+              won={isCompleted}
+            />
           ) : (
             <p className="text-sm text-gray-500">Nenhum progresso ainda.</p>
           )}
-        </div>
+        </section>
 
         <div className="bg-[#fffaf2] border border-[#eadfce] rounded-xl p-6">
           <h2 className="text-xl font-serif font-semibold mb-4">Leaderboard</h2>

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -4,6 +4,7 @@ import { getProjects } from "../api/projects";
 import { getActiveEvents, getMyEvents, joinEvent } from "../api/events";
 import JoinEventModal from "../components/JoinEventModal";
 import FeedbackModal from "../components/FeedbackModal.jsx";
+import EventProgressStatusCard from "../components/EventProgressStatusCard.jsx";
 import {
   normalizeEntityId,
   normalizeMyEventProgress,
@@ -267,43 +268,18 @@ export default function Events() {
           ) : (
             <div className="space-y-4">
               {normalizedMyEvents.map((ev) => (
-                <div
+                <EventProgressStatusCard
                   key={`${ev.eventId}-${ev.projectId ?? "no-project"}`}
-                  className="bg-[#fffaf2] border border-[#eadfce] rounded-xl p-6 shadow-sm"
-                >
-                  <p className="text-sm uppercase tracking-wide text-gray-500 mb-1">Evento</p>
-
-                  <h3 className="text-2xl font-serif font-semibold">{ev.eventName}</h3>
-
-                  <p className="text-sm text-gray-600">
-                    Projeto: {ev.projectTitle}
-                  </p>
-
-                  <p className="text-sm text-gray-700 mb-2">
-                    {ev.totalWrittenInEvent.toLocaleString("pt-BR")} / {ev.targetWords.toLocaleString("pt-BR")} palavras
-                  </p>
-
-                  <div className="h-2 bg-[#e6dccb] rounded-full overflow-hidden mb-3">
-                    <div
-                      className="h-2 bg-[#8b6b4f]"
-                      style={{ width: `${ev.percent}%` }}
-                    />
-                  </div>
-
-                  <div className="flex justify-between items-center">
-                    <span className="text-sm text-gray-600">
-                      {ev.percent}% concluído
-                    </span>
-
-                    <button
-                      type="button"
-                      onClick={() => navigate(`/events/${ev.eventId}`)}
-                      className="px-4 py-2 border rounded-lg"
-                    >
-                      Detalhes
-                    </button>
-                  </div>
-                </div>
+                  eventName={ev.eventName}
+                  projectTitle={ev.projectTitle}
+                  totalWords={ev.totalWrittenInEvent}
+                  targetWords={ev.targetWords}
+                  percent={ev.percent}
+                  remainingWords={ev.remainingWords}
+                  won={ev.won}
+                  onAction={() => navigate(`/events/${ev.eventId}`)}
+                  actionLabel="Detalhes"
+                />
               ))}
             </div>
           )}


### PR DESCRIPTION
## Resumo
- Padroniza o card de progresso de evento em Dashboard, Events e EventDetails.
- Extrai componente reutilizavel unico para visual/estado.
- Garante estado de concluido com check e barra verde em todas as telas.

## Alteracoes
- Novo componente:
  - `src/components/EventProgressStatusCard.jsx`
- Integrado em:
  - `src/components/EventProgressCard.jsx`
  - `src/pages/Events.jsx`
  - `src/pages/EventDetails.jsx`
  - `src/pages/Dashboard.jsx`

## Padroes aplicados
- Mesmo layout base de card nas 3 telas.
- Mesmos textos de progresso (`x / y palavras`, `% concluido`, restantes/meta concluida).
- Mesmo comportamento visual:
  - concluido => check verde + barra em gradiente verde.
  - em andamento => barra padrao.

## Validacao
- `npm run build`

Closes #28
