### PR TITLE
[Auth][FE] Migra sessão para fluxo sem JWT em localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ npm run dev
 ## Rotas de API esperadas
 - `POST /auth/login` -> { accessToken, user? }
 - `POST /auth/register`
+- `GET /profile/me` -> bootstrap da sessão (cookie/credenciais)
 - `GET /projects` -> lista projetos do usuário
 - `GET /projects/:id` -> detalhes
 - `GET /projects/:id/progress` -> histórico
@@ -24,7 +25,8 @@ npm run dev
 - `DELETE /progress/:progressId` -> excluir
 
 ## Observações
-- O token JWT é guardado no localStorage e enviado em `Authorization: Bearer ...`.
+- O frontend não persiste JWT em `localStorage/sessionStorage`.
+- Requisições usam `withCredentials: true` para suportar sessão baseada em cookie HttpOnly.
 - Base URL lida de `VITE_API_URL`.
 
 ## CI/CD

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -4,7 +4,6 @@ import api from "./http";
 export async function login(payload) {
   const response = await api.post("/auth/login", payload);
 
-
   return (
     response.data.accessToken ??
     response.data.AccessToken ??
@@ -33,8 +32,7 @@ export async function register({ firstName, lastName, dateOfBirth, email, passwo
   const { data } = await api.post("/auth/register", payload);
   return data;
 }
+
 export function logout() {
-  localStorage.removeItem("token");
-  localStorage.removeItem("accessToken");
-  localStorage.removeItem("jwt");
+  return Promise.resolve();
 }

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,16 +1,1 @@
-import axios from 'axios'
-
-const api = axios.create({
-  baseURL: 'http://localhost:5000/api', // ajuste se a porta for diferente
-})
-
-// intercepta cada request e adiciona o token
-api.interceptors.request.use(config => {
-  const token = localStorage.getItem('token') // supondo que você salva o JWT no login
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`
-  }
-  return config
-})
-
-export default api
+export { default } from "./http";

--- a/src/api/http.js
+++ b/src/api/http.js
@@ -6,33 +6,26 @@ import axios from "axios";
 // - Se preferir chamar a API diretamente, defina VITE_API_URL="http://localhost:5000/api" no .env.
 const baseURL =
   import.meta.env.VITE_API_URL?.replace(/\/$/, "") || "/api";
-const TOKEN_KEYS = ["token", "accessToken", "jwt"];
+let inMemoryAccessToken = null;
 
-function readStoredToken() {
-  try {
-    for (const key of TOKEN_KEYS) {
-      const value = localStorage.getItem(key);
-      if (typeof value === "string" && value.trim().length > 0) {
-        return value;
-      }
-    }
-  } catch {
-    return null;
-  }
-  return null;
+export function setAccessToken(token) {
+  inMemoryAccessToken =
+    typeof token === "string" && token.trim().length > 0
+      ? token.trim()
+      : null;
 }
 
-function clearStoredTokens() {
-  try {
-    TOKEN_KEYS.forEach((key) => localStorage.removeItem(key));
-  } catch {
-    // ignore
-  }
+export function clearAccessToken() {
+  inMemoryAccessToken = null;
+}
+
+export function getAccessToken() {
+  return inMemoryAccessToken;
 }
 
 const api = axios.create({
   baseURL,
-  withCredentials: false,
+  withCredentials: true,
 });
 
 function isPublicAuthRequest(url) {
@@ -43,12 +36,13 @@ function isPublicAuthRequest(url) {
 // 2) Interceptor p/ Authorization: Bearer <token>
 api.interceptors.request.use((config) => {
   try {
+    config.withCredentials = true;
+
     if (isPublicAuthRequest(config?.url)) {
       return config;
     }
 
-    const token = readStoredToken();
-
+    const token = getAccessToken();
     if (token) {
       config.headers = config.headers || {};
       config.headers.Authorization = `Bearer ${token}`;
@@ -64,13 +58,15 @@ api.interceptors.response.use(
   (error) => {
     const status = error?.response?.status;
     const requestUrl = String(error?.config?.url ?? "");
+    const skipAuthRedirect = Boolean(error?.config?.skipAuthRedirectOn401);
 
     if (
       status === 401 &&
+      !skipAuthRedirect &&
       !requestUrl.includes("/auth/login") &&
       !requestUrl.includes("/auth/register")
     ) {
-      clearStoredTokens();
+      clearAccessToken();
       if (typeof window !== "undefined" && window.location.pathname !== "/") {
         window.location.assign("/");
       }

--- a/src/components/LoginModal.jsx
+++ b/src/components/LoginModal.jsx
@@ -4,7 +4,7 @@ import { loginApi, register } from "../api/auth";
 import { useAuth } from "../context/AuthContext";
 import FeedbackModal from "./FeedbackModal.jsx";
 import { getAuthFriendlyMessage } from "../utils/authErrorMessage";
-import { resolvePostAuthPath } from "../utils/authRedirect";
+import { resolvePostAuthPathFromUser } from "../utils/authRedirect";
 
 export default function LoginModal({ open, onClose }) {
   const { login } = useAuth();
@@ -50,9 +50,9 @@ export default function LoginModal({ open, onClose }) {
     try {
       const token = await loginApi({ email, password });
       if (!token) throw new Error("Token não retornado pelo servidor.");
-      login(token);
+      const authenticatedUser = login(token);
       onClose?.();
-      navigate(resolvePostAuthPath(token, "/dashboard"), { replace: true });
+      navigate(resolvePostAuthPathFromUser(authenticatedUser, "/dashboard"), { replace: true });
     } catch (ex) {
       setFeedback({
         open: true,

--- a/src/components/LoginPopover.jsx
+++ b/src/components/LoginPopover.jsx
@@ -4,7 +4,7 @@ import { login as apiLogin } from "../api/auth";
 import { useAuth } from "../context/AuthContext";
 import FeedbackModal from "./FeedbackModal.jsx";
 import { getAuthFriendlyMessage } from "../utils/authErrorMessage";
-import { resolvePostAuthPath } from "../utils/authRedirect";
+import { resolvePostAuthPathFromUser } from "../utils/authRedirect";
 
 export default function LoginPopover({ open, anchorEl, onClose }) {
   const { login } = useAuth();
@@ -34,10 +34,10 @@ export default function LoginPopover({ open, anchorEl, onClose }) {
         throw new Error("Token inválido recebido do servidor.");
       }
 
-      login(token);
+      const authenticatedUser = login(token);
 
       onClose?.();
-      navigate(resolvePostAuthPath(token, "/dashboard"), { replace: true });
+      navigate(resolvePostAuthPathFromUser(authenticatedUser, "/dashboard"), { replace: true });
 
     } catch (err) {
       setFeedback({

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -4,7 +4,7 @@ import { useAuth } from "../context/AuthContext";
 import LoginPopover from "./LoginPopover";
 
 export default function Navbar() {
-  const { isAuthenticated, logout, user } = useAuth();
+  const { isAuthenticated, logout, user, isBootstrapping } = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -49,7 +49,7 @@ export default function Navbar() {
         </Link>
 
         {/* LANDING / PUBLIC (deslogado) */}
-        {!isAuthenticated && (
+        {!isAuthenticated && !isBootstrapping && (
           <div className="flex items-center gap-4">
             {!isLanding && (
               <NavLink to="/resources" className={navLink}>
@@ -82,7 +82,7 @@ export default function Navbar() {
         )}
 
         {/* APP (logado) */}
-        {isAuthenticated && (
+        {isAuthenticated && !isBootstrapping && (
           <div className="flex items-center gap-3 min-w-0">
             <nav className="flex items-center gap-2 overflow-x-auto whitespace-nowrap pb-1">
               {user?.isAdmin ? (

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,29 +1,7 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import api, { clearAccessToken, setAccessToken } from "../api/http";
 
 const AuthContext = createContext();
-const TOKEN_KEYS = ["token", "accessToken", "jwt"];
-
-function readStoredToken() {
-  try {
-    for (const key of TOKEN_KEYS) {
-      const value = localStorage.getItem(key);
-      if (typeof value === "string" && value.trim().length > 0) {
-        return value;
-      }
-    }
-  } catch {
-    return null;
-  }
-  return null;
-}
-
-function clearStoredTokens() {
-  try {
-    TOKEN_KEYS.forEach((key) => localStorage.removeItem(key));
-  } catch {
-    // ignore
-  }
-}
 
 function decodeJwtPayload(token) {
   const payloadBase64Url = token.split(".")[1];
@@ -48,80 +26,113 @@ function parseBool(value) {
   return false;
 }
 
-export function AuthProvider({ children }) {
-  const [user, setUser] = useState(null);
-  const [token, setToken] = useState(() => readStoredToken());
-
-useEffect(() => {
-  if (!token || typeof token !== "string") {
-    setUser(null);
-    return;
+function mapUserFromClaims(source) {
+  if (!source || typeof source !== "object") {
+    return null;
   }
 
-  try {
-    const decoded = decodeJwtPayload(token);
-    if (!decoded || isExpired(decoded)) {
-      clearStoredTokens();
-      setUser(null);
-      setToken(null);
-      return;
-    }
-
-    setUser({
-      id: decoded.nameid || decoded.sub || null,
-      email: decoded.email || null,
-      isAdmin: parseBool(decoded.isAdmin),
-      mustChangePassword: parseBool(decoded.mustChangePassword),
-    });
-  } catch {
-    setUser(null);
-    setToken(null);
-    clearStoredTokens();
-  }
-}, [token]);
-
-
-  function login(newToken) {
-  clearStoredTokens();
-  localStorage.setItem("token", newToken);
-  setToken(newToken);
-
-  // ✅ Decodifica e seta user imediatamente (evita race condition com ProtectedRoute)
-  try {
-    const decoded = decodeJwtPayload(newToken);
-    if (!decoded || isExpired(decoded)) {
-      throw new Error("Token expirado.");
-    }
-
-    setUser({
-      id: decoded.nameid || decoded.sub || null,
-      email: decoded.email || null,
-      isAdmin: parseBool(decoded.isAdmin),
-      mustChangePassword: parseBool(decoded.mustChangePassword),
-    });
-  } catch (err) {
-    console.error("Token inválido no login()", err);
-    setUser(null);
-    setToken(null);
-    clearStoredTokens();
-    throw err;
-  }
+  return {
+    id: source.nameid ?? source.sub ?? source.id ?? source.userId ?? null,
+    email: source.email ?? source.Email ?? null,
+    isAdmin: parseBool(source.isAdmin ?? source.IsAdmin ?? source.is_admin),
+    mustChangePassword: parseBool(
+      source.mustChangePassword ??
+        source.MustChangePassword ??
+        source.must_change_password
+    ),
+  };
 }
 
-  function logout() {
-    clearStoredTokens();
-    setToken(null);
-    setUser(null);
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [token, setToken] = useState(null);
+  const [isBootstrapping, setIsBootstrapping] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+
+    const bootstrapSession = async () => {
+      try {
+        // Bootstrap via cookie-backed session when available.
+        const { data } = await api.get("/profile/me", {
+          skipAuthRedirectOn401: true,
+        });
+
+        if (!alive) return;
+
+        const sessionUser = mapUserFromClaims(data);
+        if (sessionUser?.email) {
+          setUser(sessionUser);
+        }
+      } catch {
+        if (!alive) return;
+        setUser(null);
+        setToken(null);
+        clearAccessToken();
+      } finally {
+        if (alive) {
+          setIsBootstrapping(false);
+        }
+      }
+    };
+
+    bootstrapSession();
+
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  function login(newToken) {
+    if (typeof newToken !== "string" || newToken.trim().length === 0) {
+      throw new Error("Token inválido recebido do servidor.");
+    }
+
+    const normalizedToken = newToken.trim();
+
+    try {
+      const decoded = decodeJwtPayload(normalizedToken);
+      if (!decoded || isExpired(decoded)) {
+        throw new Error("Token expirado.");
+      }
+
+      const mapped = mapUserFromClaims(decoded);
+
+      setAccessToken(normalizedToken);
+      setToken(normalizedToken);
+      setUser(mapped);
+      setIsBootstrapping(false);
+
+      return mapped;
+    } catch (error) {
+      setUser(null);
+      setToken(null);
+      clearAccessToken();
+      throw error;
+    }
   }
 
-  const isAuthenticated = !!user;
+  function logout() {
+    clearAccessToken();
+    setToken(null);
+    setUser(null);
+    setIsBootstrapping(false);
+  }
 
-return (
-  <AuthContext.Provider value={{ user, token, login, setToken: login, logout, isAuthenticated }}>
-    {children}
-  </AuthContext.Provider>
-);
+  const value = useMemo(
+    () => ({
+      user,
+      token,
+      login,
+      setToken: login,
+      logout,
+      isAuthenticated: !!user,
+      isBootstrapping,
+    }),
+    [isBootstrapping, token, user]
+  );
 
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 export const useAuth = () => useContext(AuthContext);

--- a/src/pages/ChangePassword.jsx
+++ b/src/pages/ChangePassword.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import api from "../api/http";
-import { resolvePostAuthPath } from "../utils/authRedirect";
+import { resolvePostAuthPathFromUser } from "../utils/authRedirect";
 
 export default function ChangePassword() {
   const { login } = useAuth();
@@ -34,9 +34,9 @@ export default function ChangePassword() {
         newPassword: password,
       });
 
-      login(data.token);
+      const authenticatedUser = login(data.token);
 
-      navigate(resolvePostAuthPath(data.token, "/dashboard"), { replace: true });
+      navigate(resolvePostAuthPathFromUser(authenticatedUser, "/dashboard"), { replace: true });
     } catch (err) {
       setError(
         err?.response?.data?.message ||

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -5,7 +5,7 @@ import { useAuth } from "../context/AuthContext";
 import { loginApi } from "../api/auth";
 import FeedbackModal from "../components/FeedbackModal.jsx";
 import { getAuthFriendlyMessage } from "../utils/authErrorMessage";
-import { resolvePostAuthPath } from "../utils/authRedirect";
+import { resolvePostAuthPathFromUser } from "../utils/authRedirect";
 
 export default function Login() {
   const navigate = useNavigate();
@@ -28,8 +28,8 @@ export default function Login() {
     try {
       const token = await loginApi({ email, password });
       if (!token) throw new Error("Token não retornado pelo backend");
-      login(token);
-      navigate(resolvePostAuthPath(token, "/dashboard"), { replace: true });
+      const authenticatedUser = login(token);
+      navigate(resolvePostAuthPathFromUser(authenticatedUser, "/dashboard"), { replace: true });
     } catch (ex) {
       setFeedback({
         open: true,

--- a/src/routes/ProtectedRoute.jsx
+++ b/src/routes/ProtectedRoute.jsx
@@ -2,9 +2,13 @@ import { Navigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 
 export default function ProtectedRoute({ children }) {
-  const { user, token } = useAuth();
+  const { user, isBootstrapping } = useAuth();
 
-  if (!user || !token) {
+  if (isBootstrapping) {
+    return null;
+  }
+
+  if (!user) {
     return <Navigate to="/" replace />;
   }
 

--- a/src/utils/authRedirect.js
+++ b/src/utils/authRedirect.js
@@ -23,6 +23,30 @@ function isAdminFromRole(roleClaim) {
   return false;
 }
 
+export function resolvePostAuthPathFromUser(user, fallback = "/dashboard") {
+  if (!user || typeof user !== "object") {
+    return fallback;
+  }
+
+  const mustChangePassword = parseBool(
+    user.mustChangePassword ??
+      user.MustChangePassword ??
+      user.must_change_password
+  );
+
+  const isAdmin =
+    parseBool(user.isAdmin ?? user.IsAdmin ?? user.is_admin) ||
+    isAdminFromRole(
+      user.role ??
+        user.roles ??
+        user["http://schemas.microsoft.com/ws/2008/06/identity/claims/role"]
+    );
+
+  if (mustChangePassword) return "/change-password";
+  if (isAdmin) return "/admin/events";
+  return fallback;
+}
+
 export function resolvePostAuthPath(token, fallback = "/dashboard") {
   if (typeof token !== "string" || token.trim().length === 0) {
     return fallback;
@@ -30,24 +54,7 @@ export function resolvePostAuthPath(token, fallback = "/dashboard") {
 
   try {
     const decoded = decodeJwtPayload(token) || {};
-
-    const mustChangePassword = parseBool(
-      decoded.mustChangePassword ??
-      decoded.MustChangePassword ??
-      decoded.must_change_password
-    );
-
-    const isAdmin =
-      parseBool(decoded.isAdmin ?? decoded.IsAdmin ?? decoded.is_admin) ||
-      isAdminFromRole(
-        decoded.role ??
-        decoded.roles ??
-        decoded["http://schemas.microsoft.com/ws/2008/06/identity/claims/role"]
-      );
-
-    if (mustChangePassword) return "/change-password";
-    if (isAdmin) return "/admin/events";
-    return fallback;
+    return resolvePostAuthPathFromUser(decoded, fallback);
   } catch {
     return fallback;
   }


### PR DESCRIPTION
Resumo: remove persistencia de JWT em local/session storage e prepara sessao por cookie HttpOnly no cliente frontend.

Entregas:
- remove leitura/escrita de token em storage para auth
- cliente HTTP com withCredentials true
- token de acesso somente em memoria (runtime)
- bootstrap de sessao via endpoint profile/me
- guards/rotas protegidas sem dependencia de token local
- ajustes em login e troca de senha para redirecionar por estado do usuario
- README atualizado

Validacao:
- npm run build

Observacao:
- para sessao persistir apos refresh sem expor token ao JS, backend/proxy precisa autenticar via cookie HttpOnly de forma compativel com profile/me.

Closes #43