### PR TITLE
ci: rodar Build Frontend em PRs para staging

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - staging
   workflow_dispatch:
     inputs:
       target:
@@ -67,7 +68,7 @@ jobs:
       - deploy
     needs:
       - build
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy' && github.event.inputs.target == 'staging')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/staging') || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy' && github.event.inputs.target == 'staging')
     environment: staging
     env:
       DEPLOY_ROOT: ${{ secrets.DEPLOY_ROOT }}


### PR DESCRIPTION
Ajusta o workflow do frontend para disparar em `pull_request` para `staging` (alem de `main`).

Motivacao
- a branch `staging` agora esta protegida com check obrigatorio `Build Frontend`
- sem esse gatilho, PRs para `staging` ficam sem checks e nao podem ser mergeados

Mudanca
- adiciona `staging` no trigger `on.pull_request.branches` do pipeline