### PR TITLE
feat: jornada pós-evento com estados e CTAs explícitos (#61)

### DIFF
--- a/src/components/EventParticipantJourneyCard.jsx
+++ b/src/components/EventParticipantJourneyCard.jsx
@@ -1,0 +1,64 @@
+import EventProgressStatusCard from "./EventProgressStatusCard.jsx";
+import { resolveParticipantJourney } from "../utils/participantJourney";
+
+export default function EventParticipantJourneyCard({
+  status,
+  onOpenDetails,
+  onOpenValidate,
+  onOpenWinner,
+  onOpenProject,
+  className = "",
+}) {
+  const journey = resolveParticipantJourney(status);
+
+  const handlers = {
+    details: onOpenDetails,
+    validate: onOpenValidate,
+    winner: onOpenWinner,
+    project: onOpenProject,
+  };
+
+  const primaryHandler = handlers[journey.primaryAction] || onOpenDetails || null;
+  const primaryLabel = primaryHandler ? journey.primaryLabel : "Detalhes";
+  const showSecondaryDetails = Boolean(
+    onOpenDetails && journey.primaryAction !== "details"
+  );
+
+  return (
+    <div className={`space-y-2 ${className}`.trim()}>
+      <EventProgressStatusCard
+        eventName={status?.eventName}
+        projectTitle={status?.projectTitle}
+        totalWords={status?.totalWords}
+        targetWords={status?.targetWords}
+        percent={status?.percent}
+        remainingWords={status?.remainingWords}
+        won={status?.isWinner}
+        onAction={primaryHandler || undefined}
+        actionLabel={primaryLabel}
+      />
+
+      <div className="rounded-xl border border-[#eadfce] bg-[#fffaf2] p-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span
+            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${journey.badgeClass}`}
+          >
+            {journey.label}
+          </span>
+
+          {showSecondaryDetails && (
+            <button
+              type="button"
+              className="button"
+              onClick={onOpenDetails}
+            >
+              Ver detalhes
+            </button>
+          )}
+        </div>
+
+        <p className="mt-2 text-sm text-gray-700">{journey.message}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EventProgressCard.jsx
+++ b/src/components/EventProgressCard.jsx
@@ -4,13 +4,18 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   getMyEvents,
+  getEventParticipantStatus,
   getEventProjectProgress,
 } from "../api/events";
 import {
   normalizeEntityId,
   normalizeEventProjectProgress,
 } from "../utils/eventProgress";
-import EventProgressStatusCard from "./EventProgressStatusCard.jsx";
+import {
+  buildFallbackParticipantStatus,
+  normalizeParticipantStatus,
+} from "../utils/participantJourney";
+import EventParticipantJourneyCard from "./EventParticipantJourneyCard.jsx";
 
 export default function EventProgressCard({
   eventId,
@@ -22,7 +27,9 @@ export default function EventProgressCard({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [progress, setProgress] = useState(null);
+  const [participantStatus, setParticipantStatus] = useState(null);
   const [resolvedEventId, setResolvedEventId] = useState("");
+  const [resolvedProjectId, setResolvedProjectId] = useState("");
 
   useEffect(() => {
     let alive = true;
@@ -31,7 +38,9 @@ export default function EventProgressCard({
       setLoading(true);
       setError("");
       setProgress(null);
+      setParticipantStatus(null);
       setResolvedEventId("");
+      setResolvedProjectId("");
 
       try {
         let resolvedEventId = eventId;
@@ -66,7 +75,35 @@ export default function EventProgressCard({
         if (!alive) return;
 
         setResolvedEventId(resolvedEventId);
+        setResolvedProjectId(resolvedProjectId);
         setProgress(data);
+
+        try {
+          const unifiedStatus = await getEventParticipantStatus(
+            resolvedEventId,
+            resolvedProjectId
+          );
+          if (!alive) return;
+          setParticipantStatus(normalizeParticipantStatus(unifiedStatus));
+        } catch {
+          if (!alive) return;
+          const normalizedProgress = normalizeEventProjectProgress(data);
+          setParticipantStatus(
+            buildFallbackParticipantStatus({
+              eventId: resolvedEventId,
+              projectId: resolvedProjectId,
+              eventName: normalizedProgress?.eventName ?? "Evento",
+              projectTitle: projectTitle ?? "Participação individual",
+              totalWords: normalizedProgress?.totalWrittenInEvent ?? 0,
+              targetWords: normalizedProgress?.targetWords ?? 0,
+              percent: normalizedProgress?.percent ?? 0,
+              remainingWords: normalizedProgress?.remainingWords ?? 0,
+              isEventClosed: false,
+              isEventActive: true,
+              isWinner: normalizedProgress?.won ?? false,
+            })
+          );
+        }
       } catch {
         if (alive) {
           setError("Não foi possível carregar o progresso do evento.");
@@ -79,7 +116,7 @@ export default function EventProgressCard({
     return () => {
       alive = false;
     };
-  }, [eventId, projectId]);
+  }, [eventId, projectId, projectTitle]);
 
   /* ===================== RENDER ===================== */
 
@@ -88,10 +125,52 @@ export default function EventProgressCard({
     return normalizeEventProjectProgress(progress);
   }, [progress]);
 
+  const resolvedStatus = useMemo(() => {
+    if (participantStatus) return participantStatus;
+    if (!normalizedProgress) return null;
+
+    return buildFallbackParticipantStatus({
+      eventId: resolvedEventId,
+      projectId: resolvedProjectId,
+      eventName: normalizedProgress.eventName,
+      projectTitle: projectTitle ?? "Participação individual",
+      totalWords: normalizedProgress.totalWrittenInEvent,
+      targetWords: normalizedProgress.targetWords,
+      percent: normalizedProgress.percent,
+      remainingWords: normalizedProgress.remainingWords,
+      isEventClosed: false,
+      isEventActive: true,
+      isWinner: normalizedProgress.won,
+    });
+  }, [
+    participantStatus,
+    normalizedProgress,
+    resolvedEventId,
+    resolvedProjectId,
+    projectTitle,
+  ]);
+
   const detailsHandler = useMemo(() => {
     if (!showDetailsAction || !resolvedEventId) return null;
     return () => navigate(`/events/${resolvedEventId}`);
   }, [showDetailsAction, resolvedEventId, navigate]);
+
+  const validateHandler = useMemo(() => {
+    if (!resolvedEventId || !resolvedProjectId) return null;
+    return () =>
+      navigate(`/validate?eventId=${resolvedEventId}&projectId=${resolvedProjectId}`);
+  }, [resolvedEventId, resolvedProjectId, navigate]);
+
+  const winnerHandler = useMemo(() => {
+    if (!resolvedEventId || !resolvedProjectId) return null;
+    return () =>
+      navigate(`/winner?eventId=${resolvedEventId}&projectId=${resolvedProjectId}`);
+  }, [resolvedEventId, resolvedProjectId, navigate]);
+
+  const projectHandler = useMemo(() => {
+    if (!resolvedProjectId) return null;
+    return () => navigate(`/projects/${resolvedProjectId}`);
+  }, [resolvedProjectId, navigate]);
 
   if (loading) {
     return (
@@ -111,19 +190,15 @@ export default function EventProgressCard({
     );
   }
 
-  if (!normalizedProgress) return null;
+  if (!resolvedStatus) return null;
 
   return (
-    <EventProgressStatusCard
-      eventName={normalizedProgress.eventName}
-      projectTitle={projectTitle}
-      totalWords={normalizedProgress.totalWrittenInEvent}
-      targetWords={normalizedProgress.targetWords}
-      percent={normalizedProgress.percent}
-      remainingWords={normalizedProgress.remainingWords}
-      won={normalizedProgress.won}
-      onAction={detailsHandler || undefined}
-      actionLabel="Detalhes"
+    <EventParticipantJourneyCard
+      status={resolvedStatus}
+      onOpenDetails={detailsHandler || undefined}
+      onOpenValidate={validateHandler || undefined}
+      onOpenWinner={winnerHandler || undefined}
+      onOpenProject={projectHandler || undefined}
     />
   );
 }

--- a/src/pages/EventDetails.jsx
+++ b/src/pages/EventDetails.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
   getEventById,
+  getEventParticipantStatus,
   getMyEvents,
   getEventProjectProgress,
   getEventLeaderboard,
@@ -9,8 +10,12 @@ import {
 } from "../api/events";
 import { useAuth } from "../context/AuthContext";
 import WordWarPanel from "../components/WordWarPanel.jsx";
-import EventProgressStatusCard from "../components/EventProgressStatusCard.jsx";
+import EventParticipantJourneyCard from "../components/EventParticipantJourneyCard.jsx";
 import { normalizeEventProjectProgress } from "../utils/eventProgress";
+import {
+  buildFallbackParticipantStatus,
+  normalizeParticipantStatus,
+} from "../utils/participantJourney";
 
 export default function EventDetails() {
   const { user } = useAuth();
@@ -20,6 +25,7 @@ export default function EventDetails() {
   const [event, setEvent] = useState(null);
   const [myEvent, setMyEvent] = useState(null);
   const [progress, setProgress] = useState(null);
+  const [participantStatus, setParticipantStatus] = useState(null);
   const [leaderboard, setLeaderboard] = useState([]);
 
   const [loading, setLoading] = useState(true);
@@ -63,9 +69,31 @@ export default function EventDetails() {
         : null,
     [progress, event?.defaultTargetWords]
   );
+  const effectiveStatus = useMemo(() => getEffectiveStatus(event), [event]);
+  const isEventClosed = effectiveStatus === "closed";
+  const effectiveStatusLabel = useMemo(
+    () => getEffectiveStatusLabel(event),
+    [event]
+  );
 
-  const percent = normalizedProgress?.percent ?? 0;
-  const isCompleted = normalizedProgress?.won ?? false;
+  const resolvedParticipantStatus = useMemo(() => {
+    if (participantStatus) return participantStatus;
+    if (!event || !myEvent || !normalizedProgress) return null;
+
+    return buildFallbackParticipantStatus({
+      eventId: myEvent.eventId,
+      projectId: myEvent.projectId,
+      eventName: event.name ?? "Evento",
+      projectTitle: myEvent.projectTitle,
+      totalWords: normalizedProgress.totalWrittenInEvent,
+      targetWords: normalizedProgress.targetWords,
+      percent: normalizedProgress.percent,
+      remainingWords: normalizedProgress.remainingWords,
+      isEventClosed,
+      isEventActive: !isEventClosed,
+      isWinner: normalizedProgress.won,
+    });
+  }, [participantStatus, event, myEvent, normalizedProgress, isEventClosed]);
 
   useEffect(() => {
     let mounted = true;
@@ -118,18 +146,27 @@ export default function EventDetails() {
     (async () => {
       if (!myEvent?.projectId) {
         setProgress(null);
+        setParticipantStatus(null);
         return;
       }
 
       try {
-        const eventProgress = await getEventProjectProgress(
-          myEvent.eventId,
-          myEvent.projectId
-        );
+        const [eventProgress, unifiedStatus] = await Promise.all([
+          getEventProjectProgress(myEvent.eventId, myEvent.projectId).catch(() => null),
+          getEventParticipantStatus(myEvent.eventId, myEvent.projectId).catch(() => null),
+        ]);
 
-        if (mounted) setProgress(eventProgress);
+        if (!mounted) return;
+
+        setProgress(eventProgress);
+        setParticipantStatus(
+          unifiedStatus ? normalizeParticipantStatus(unifiedStatus) : null
+        );
       } catch {
-        if (mounted) setProgress(null);
+        if (mounted) {
+          setProgress(null);
+          setParticipantStatus(null);
+        }
       }
     })();
 
@@ -141,9 +178,6 @@ export default function EventDetails() {
   if (loading) return <p className="p-6">Carregando evento…</p>;
   if (error) return <p className="p-6 text-red-600">{error}</p>;
   if (!event) return null;
-
-  const effectiveStatusLabel = getEffectiveStatusLabel(event);
-  const isEventClosed = getEffectiveStatus(event) === "closed";
 
   return (
     <header className="hero">
@@ -199,15 +233,16 @@ export default function EventDetails() {
             <p className="text-sm text-gray-500">
               Você ainda não participa deste evento.
             </p>
-          ) : normalizedProgress ? (
-            <EventProgressStatusCard
-              eventName={event.name}
-              projectTitle={myEvent.projectTitle}
-              totalWords={normalizedProgress.totalWrittenInEvent}
-              targetWords={normalizedProgress.targetWords}
-              percent={percent}
-              remainingWords={normalizedProgress.remainingWords}
-              won={isCompleted}
+          ) : resolvedParticipantStatus ? (
+            <EventParticipantJourneyCard
+              status={resolvedParticipantStatus}
+              onOpenValidate={() =>
+                navigate(`/validate?eventId=${myEvent.eventId}&projectId=${myEvent.projectId}`)
+              }
+              onOpenWinner={() =>
+                navigate(`/winner?eventId=${myEvent.eventId}&projectId=${myEvent.projectId}`)
+              }
+              onOpenProject={() => navigate(`/projects/${myEvent.projectId}`)}
             />
           ) : (
             <p className="text-sm text-gray-500">Nenhum progresso ainda.</p>
@@ -257,19 +292,7 @@ export default function EventDetails() {
           </button>
 
           <div className="flex items-center gap-2">
-            {myEvent && (
-              <button
-                type="button"
-                className="px-4 py-2 border rounded-lg"
-                onClick={() =>
-                  navigate(`/winner?eventId=${eventId}&projectId=${myEvent.projectId}`)
-                }
-              >
-                Central do vencedor
-              </button>
-            )}
-
-            {myEvent && (
+            {myEvent && !isEventClosed && (
               <button
                 onClick={async () => {
                   await leaveEvent(eventId, myEvent.projectId);

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -1,15 +1,25 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getProjects } from "../api/projects";
-import { getActiveEvents, getMyEvents, joinEvent } from "../api/events";
+import {
+  getActiveEvents,
+  getEventParticipantStatus,
+  getMyEvents,
+  joinEvent,
+} from "../api/events";
 import JoinEventModal from "../components/JoinEventModal";
 import FeedbackModal from "../components/FeedbackModal.jsx";
-import EventProgressStatusCard from "../components/EventProgressStatusCard.jsx";
+import EventParticipantJourneyCard from "../components/EventParticipantJourneyCard.jsx";
 import {
   normalizeEntityId,
   normalizeMyEventProgress,
   resolveTargetWords,
 } from "../utils/eventProgress";
+import {
+  buildFallbackParticipantStatus,
+  makeParticipantStatusKey,
+  normalizeParticipantStatus,
+} from "../utils/participantJourney";
 
 function getApiErrorMessage(error) {
   const fallback = "Não foi possível concluir sua participação agora. Tente novamente.";
@@ -56,6 +66,8 @@ export default function Events() {
 
   const [joinModalEvent, setJoinModalEvent] = useState(null);
   const [joining, setJoining] = useState(false);
+  const [participantStatuses, setParticipantStatuses] = useState({});
+  const [loadingParticipantStatuses, setLoadingParticipantStatuses] = useState(false);
 
   const [feedback, setFeedback] = useState({
     open: false,
@@ -108,6 +120,30 @@ export default function Events() {
     [normalizedMyEvents, activeEventsById]
   );
 
+  const statusByEntry = useMemo(() => {
+    const fallback = {};
+    for (const entry of normalizedMyEvents) {
+      if (!entry.eventId || !entry.projectId) continue;
+      const key = makeParticipantStatusKey(entry.eventId, entry.projectId);
+      fallback[key] =
+        participantStatuses[key] ||
+        buildFallbackParticipantStatus({
+          eventId: entry.eventId,
+          projectId: entry.projectId,
+          eventName: entry.eventName,
+          projectTitle: entry.projectTitle,
+          totalWords: entry.totalWrittenInEvent,
+          targetWords: entry.targetWords,
+          percent: entry.percent,
+          remainingWords: entry.remainingWords,
+          isEventClosed: !activeEventsById.has(normalizeEntityId(entry.eventId)),
+          isEventActive: activeEventsById.has(normalizeEntityId(entry.eventId)),
+          isWinner: entry.won,
+        });
+    }
+    return fallback;
+  }, [normalizedMyEvents, participantStatuses, activeEventsById]);
+
   useEffect(() => {
     let mounted = true;
 
@@ -140,6 +176,59 @@ export default function Events() {
       mounted = false;
     };
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const targets = normalizedMyEvents.filter((entry) => entry.eventId && entry.projectId);
+      if (!targets.length) {
+        setParticipantStatuses({});
+        setLoadingParticipantStatuses(false);
+        return;
+      }
+
+      setLoadingParticipantStatuses(true);
+
+      const results = await Promise.allSettled(
+        targets.map((entry) => getEventParticipantStatus(entry.eventId, entry.projectId))
+      );
+
+      if (cancelled) return;
+
+      const next = {};
+      targets.forEach((entry, index) => {
+        const key = makeParticipantStatusKey(entry.eventId, entry.projectId);
+        const result = results[index];
+        if (result.status === "fulfilled") {
+          const normalized = normalizeParticipantStatus(result.value);
+          if (normalized) next[key] = normalized;
+          return;
+        }
+
+        next[key] = buildFallbackParticipantStatus({
+          eventId: entry.eventId,
+          projectId: entry.projectId,
+          eventName: entry.eventName,
+          projectTitle: entry.projectTitle,
+          totalWords: entry.totalWrittenInEvent,
+          targetWords: entry.targetWords,
+          percent: entry.percent,
+          remainingWords: entry.remainingWords,
+          isEventClosed: !activeEventsById.has(normalizeEntityId(entry.eventId)),
+          isEventActive: activeEventsById.has(normalizeEntityId(entry.eventId)),
+          isWinner: entry.won,
+        });
+      });
+
+      setParticipantStatuses(next);
+      setLoadingParticipantStatuses(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [normalizedMyEvents, activeEventsById]);
 
   if (loading) return <p className="p-6">Carregando eventos…</p>;
   if (error) return <p className="p-6 text-red-600">{error}</p>;
@@ -283,21 +372,50 @@ export default function Events() {
             <p className="text-sm text-gray-500">Você ainda não participa de nenhum evento ativo.</p>
           ) : (
             <div className="space-y-4">
-              {activeMyEvents.map((ev) => (
-                <EventProgressStatusCard
-                  key={`${ev.eventId}-${ev.projectId ?? "no-project"}`}
-                  eventName={ev.eventName}
-                  projectTitle={ev.projectTitle}
-                  totalWords={ev.totalWrittenInEvent}
-                  targetWords={ev.targetWords}
-                  percent={ev.percent}
-                  remainingWords={ev.remainingWords}
-                  won={ev.won}
-                  onAction={() => navigate(`/events/${ev.eventId}`)}
-                  actionLabel="Detalhes"
-                />
-              ))}
+              {activeMyEvents.map((ev) => {
+                const hasProject = Boolean(ev.projectId);
+                const status = hasProject
+                  ? statusByEntry[makeParticipantStatusKey(ev.eventId, ev.projectId)]
+                  : buildFallbackParticipantStatus({
+                      eventId: ev.eventId,
+                      projectId: null,
+                      eventName: ev.eventName,
+                      projectTitle: ev.projectTitle,
+                      totalWords: ev.totalWrittenInEvent,
+                      targetWords: ev.targetWords,
+                      percent: ev.percent,
+                      remainingWords: ev.remainingWords,
+                      isEventClosed: false,
+                      isEventActive: true,
+                      isWinner: ev.won,
+                    });
+
+                return (
+                  <EventParticipantJourneyCard
+                    key={`${ev.eventId}-${ev.projectId ?? "no-project"}`}
+                    status={status}
+                    onOpenDetails={() => navigate(`/events/${ev.eventId}`)}
+                    onOpenValidate={
+                      hasProject
+                        ? () =>
+                            navigate(`/validate?eventId=${ev.eventId}&projectId=${ev.projectId}`)
+                        : undefined
+                    }
+                    onOpenWinner={
+                      hasProject
+                        ? () =>
+                            navigate(`/winner?eventId=${ev.eventId}&projectId=${ev.projectId}`)
+                        : undefined
+                    }
+                    onOpenProject={hasProject ? () => navigate(`/projects/${ev.projectId}`) : undefined}
+                  />
+                );
+              })}
             </div>
+          )}
+
+          {loadingParticipantStatuses && (
+            <p className="text-xs text-gray-500 mt-2">Atualizando status da jornada…</p>
           )}
         </section>
 
@@ -310,20 +428,45 @@ export default function Events() {
             <p className="text-sm text-gray-500">Você ainda não tem eventos encerrados.</p>
           ) : (
             <div className="space-y-4">
-              {closedMyEvents.map((ev) => (
-                <EventProgressStatusCard
-                  key={`closed-${ev.eventId}-${ev.projectId ?? "no-project"}`}
-                  eventName={ev.eventName}
-                  projectTitle={ev.projectTitle}
-                  totalWords={ev.totalWrittenInEvent}
-                  targetWords={ev.targetWords}
-                  percent={ev.percent}
-                  remainingWords={ev.remainingWords}
-                  won={ev.won}
-                  onAction={() => navigate(`/events/${ev.eventId}`)}
-                  actionLabel="Detalhes"
-                />
-              ))}
+              {closedMyEvents.map((ev) => {
+                const hasProject = Boolean(ev.projectId);
+                const status = hasProject
+                  ? statusByEntry[makeParticipantStatusKey(ev.eventId, ev.projectId)]
+                  : buildFallbackParticipantStatus({
+                      eventId: ev.eventId,
+                      projectId: null,
+                      eventName: ev.eventName,
+                      projectTitle: ev.projectTitle,
+                      totalWords: ev.totalWrittenInEvent,
+                      targetWords: ev.targetWords,
+                      percent: ev.percent,
+                      remainingWords: ev.remainingWords,
+                      isEventClosed: true,
+                      isEventActive: false,
+                      isWinner: ev.won,
+                    });
+
+                return (
+                  <EventParticipantJourneyCard
+                    key={`closed-${ev.eventId}-${ev.projectId ?? "no-project"}`}
+                    status={status}
+                    onOpenDetails={() => navigate(`/events/${ev.eventId}`)}
+                    onOpenValidate={
+                      hasProject
+                        ? () =>
+                            navigate(`/validate?eventId=${ev.eventId}&projectId=${ev.projectId}`)
+                        : undefined
+                    }
+                    onOpenWinner={
+                      hasProject
+                        ? () =>
+                            navigate(`/winner?eventId=${ev.eventId}&projectId=${ev.projectId}`)
+                        : undefined
+                    }
+                    onOpenProject={hasProject ? () => navigate(`/projects/${ev.projectId}`) : undefined}
+                  />
+                );
+              })}
             </div>
           )}
         </section>

--- a/src/pages/Validate.jsx
+++ b/src/pages/Validate.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { getProjects } from "../api/projects";
 import { getActiveEvents } from "../api/events";
 import { getValidationStatus, submitValidation } from "../api/validation";
@@ -132,6 +132,10 @@ function countWordsStrict(text) {
 
 export default function Validate() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const query = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const requestedProjectId = query.get("projectId") || "";
+  const requestedEventId = query.get("eventId") || "";
   const [projects, setProjects] = useState([]);
   const [events, setEvents] = useState([]);
   const [projectId, setProjectId] = useState("");
@@ -163,11 +167,42 @@ export default function Validate() {
         const [ps, evs] = await Promise.all([getProjects(), getActiveEvents()]);
         if (cancelled) return;
         const list = Array.isArray(ps) ? ps : [];
-        const eventsList = Array.isArray(evs) && evs.length ? evs : [];
+        const activeEventsList = Array.isArray(evs?.items)
+          ? evs.items
+          : Array.isArray(evs)
+            ? evs
+            : [];
+        const hasRequestedEvent = activeEventsList.some(
+          (ev) => String(ev?.id ?? ev?.Id ?? "") === requestedEventId
+        );
+        const eventsList =
+          requestedEventId && !hasRequestedEvent
+            ? [
+                {
+                  id: requestedEventId,
+                  name: "Evento selecionado",
+                },
+                ...activeEventsList,
+              ]
+            : activeEventsList;
+
+        const hasRequestedProject = list.some(
+          (project) => String(project?.id ?? project?.projectId ?? "") === requestedProjectId
+        );
+
         setProjects(list);
         setEvents(eventsList);
-        if (list[0]) setProjectId(list[0].id ?? list[0].projectId);
-        if (eventsList[0]) setEventId(eventsList[0].id ?? eventsList[0].Id);
+        if (requestedProjectId && hasRequestedProject) {
+          setProjectId(requestedProjectId);
+        } else if (list[0]) {
+          setProjectId(list[0].id ?? list[0].projectId);
+        }
+
+        if (requestedEventId) {
+          setEventId(requestedEventId);
+        } else if (eventsList[0]) {
+          setEventId(eventsList[0].id ?? eventsList[0].Id);
+        }
       } catch (e) {
         if (cancelled) return;
         setErr(toFriendlyApiMessage(e, "Falha ao carregar dados para validação."));
@@ -177,7 +212,7 @@ export default function Validate() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [requestedEventId, requestedProjectId]);
 
   useEffect(() => {
     if (!projectId || !eventId) {
@@ -319,7 +354,8 @@ export default function Validate() {
         title: "Validação concluída",
         message: `Projeto validado com ${chosenTotal.toLocaleString("pt-BR")} palavras.`,
         primaryLabel: "OK",
-        onPrimary: () => navigate("/winner"),
+        onPrimary: () =>
+          navigate(`/winner?eventId=${eventId}&projectId=${projectId}`),
       });
     } catch (e) {
       setFeedback({

--- a/src/utils/participantJourney.js
+++ b/src/utils/participantJourney.js
@@ -1,0 +1,206 @@
+import { normalizeEntityId } from "./eventProgress";
+
+function toSafeNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function makeParticipantStatusKey(eventId, projectId) {
+  return `${normalizeEntityId(eventId)}::${normalizeEntityId(projectId)}`;
+}
+
+export function normalizeParticipantStatus(payload) {
+  if (!payload || typeof payload !== "object") return null;
+
+  const targetWords = Math.max(0, Math.round(toSafeNumber(payload?.targetWords ?? payload?.TargetWords)));
+  const totalWords = Math.max(0, Math.round(toSafeNumber(payload?.totalWords ?? payload?.TotalWords)));
+  const remainingWordsRaw = payload?.remainingWords ?? payload?.RemainingWords;
+  const remainingWords = Math.max(
+    0,
+    Math.round(
+      Number.isFinite(Number(remainingWordsRaw))
+        ? Number(remainingWordsRaw)
+        : Math.max(0, targetWords - totalWords)
+    )
+  );
+
+  const percentRaw = payload?.percent ?? payload?.Percent;
+  const percent = Math.max(
+    0,
+    Math.min(
+      100,
+      Math.round(
+        Number.isFinite(Number(percentRaw))
+          ? Number(percentRaw)
+          : targetWords > 0
+            ? (totalWords * 100) / targetWords
+            : 0
+      )
+    )
+  );
+
+  return {
+    eventId: payload?.eventId ?? payload?.EventId ?? "",
+    projectId: payload?.projectId ?? payload?.ProjectId ?? null,
+    eventName: payload?.eventName ?? payload?.EventName ?? "Evento",
+    projectTitle: payload?.projectTitle ?? payload?.ProjectTitle ?? "Projeto",
+    eventStatus: String(payload?.eventStatus ?? payload?.EventStatus ?? "").toLowerCase(),
+    isEventActive: Boolean(payload?.isEventActive ?? payload?.IsEventActive),
+    isEventClosed: Boolean(payload?.isEventClosed ?? payload?.IsEventClosed),
+    targetWords,
+    totalWords,
+    remainingWords,
+    percent,
+    isValidated: Boolean(payload?.isValidated ?? payload?.IsValidated),
+    isWinner: Boolean(payload?.isWinner ?? payload?.IsWinner),
+    isEligible: Boolean(payload?.isEligible ?? payload?.IsEligible),
+    canValidate: Boolean(payload?.canValidate ?? payload?.CanValidate),
+    eligibilityStatus: String(
+      payload?.eligibilityStatus ?? payload?.EligibilityStatus ?? ""
+    ).toLowerCase(),
+    eligibilityMessage: String(
+      payload?.eligibilityMessage ?? payload?.EligibilityMessage ?? ""
+    ),
+    validationBlockReason:
+      payload?.validationBlockReason ?? payload?.ValidationBlockReason ?? null,
+    validatedAtUtc: payload?.validatedAtUtc ?? payload?.ValidatedAtUtc ?? null,
+  };
+}
+
+export function buildFallbackParticipantStatus({
+  eventId,
+  projectId,
+  eventName,
+  projectTitle,
+  targetWords,
+  totalWords,
+  percent,
+  remainingWords,
+  isEventClosed = false,
+  isEventActive = !isEventClosed,
+  isWinner = false,
+}) {
+  return normalizeParticipantStatus({
+    eventId,
+    projectId,
+    eventName,
+    projectTitle,
+    eventStatus: isEventClosed ? "closed" : isEventActive ? "active" : "scheduled",
+    isEventActive,
+    isEventClosed,
+    targetWords,
+    totalWords,
+    percent,
+    remainingWords,
+    isValidated: false,
+    isWinner,
+    isEligible: Boolean(isWinner),
+    canValidate: false,
+    eligibilityStatus: isWinner ? "eligible" : isEventClosed ? "not_eligible" : "in_progress",
+    eligibilityMessage: isWinner
+      ? "Goodies de vencedor liberados."
+      : isEventClosed
+        ? "Evento encerrado."
+        : "Continue escrevendo para atingir a meta do evento.",
+    validationBlockReason: null,
+  });
+}
+
+function formatDate(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return "";
+  return date.toLocaleDateString("pt-BR");
+}
+
+export function resolveParticipantJourney(status) {
+  if (!status) {
+    return {
+      key: "pending",
+      label: "Aguardando",
+      badgeClass: "bg-slate-100 text-slate-700",
+      message: "Não foi possível carregar seu status agora.",
+      primaryAction: "details",
+      primaryLabel: "Detalhes",
+    };
+  }
+
+  if (status.isValidated && status.isWinner) {
+    return {
+      key: "winner",
+      label: "Winner",
+      badgeClass: "bg-emerald-100 text-emerald-700",
+      message: "Validação concluída. Goodies de vencedor liberados.",
+      primaryAction: "winner",
+      primaryLabel: "Baixar goodies",
+    };
+  }
+
+  if (status.isValidated) {
+    return {
+      key: "validated",
+      label: "Validado",
+      badgeClass: "bg-green-100 text-green-700",
+      message: `Projeto validado em ${formatDate(status.validatedAtUtc) || "data recente"}.`,
+      primaryAction: "details",
+      primaryLabel: "Ver resultado",
+    };
+  }
+
+  if (status.canValidate || status.eligibilityStatus === "pending_validation") {
+    const isClosedLike =
+      status.isEventClosed ||
+      status.eventStatus === "closed" ||
+      status.eventStatus === "disabled";
+    return {
+      key: isClosedLike ? "pending-validation" : "ready",
+      label: isClosedLike ? "Pendente de validação" : "Apto para validar",
+      badgeClass: isClosedLike ? "bg-orange-100 text-orange-800" : "bg-amber-100 text-amber-800",
+      message:
+        status.validationBlockReason ||
+        status.eligibilityMessage ||
+        "Meta atingida. Faça a validação final para liberar os goodies.",
+      primaryAction: "validate",
+      primaryLabel: "Validar agora",
+    };
+  }
+
+  if (status.isEventClosed) {
+    const hasWindowBlock =
+      String(status.validationBlockReason ?? "").toLowerCase().includes("janela");
+    if (hasWindowBlock) {
+      return {
+        key: "closed-window",
+        label: "Janela encerrada",
+        badgeClass: "bg-amber-100 text-amber-800",
+        message: status.validationBlockReason,
+        primaryAction: "details",
+        primaryLabel: "Ver resultado",
+      };
+    }
+
+    return {
+      key: "closed-not-eligible",
+      label: "Encerrado sem elegibilidade",
+      badgeClass: "bg-slate-100 text-slate-700",
+      message:
+        status.validationBlockReason ||
+        status.eligibilityMessage ||
+        "Evento encerrado sem elegibilidade de vencedor.",
+      primaryAction: "details",
+      primaryLabel: "Ver resultado",
+    };
+  }
+
+  return {
+    key: "in-progress",
+    label: "Em andamento",
+    badgeClass: "bg-blue-100 text-blue-700",
+    message:
+      status.remainingWords > 0
+        ? `Faltam ${status.remainingWords.toLocaleString("pt-BR")} palavras para atingir a meta.`
+        : status.eligibilityMessage || "Continue escrevendo para progredir no evento.",
+    primaryAction: "project",
+    primaryLabel: "Continuar no projeto",
+  };
+}


### PR DESCRIPTION
## Resumo
- adiciona modelo unificado de estado do participante (em andamento, apto, pendente validação, validado, winner, encerrado sem elegibilidade)
- aplica CTAs contextuais por estado (validar, baixar goodies, continuar no projeto, ver resultado)
- oculta ação incompatível com evento encerrado em EventDetails (ex.: sair do evento)
- padroniza visual de status em Events/EventDetails e reaproveita no Dashboard
- permite deep link de validação com eventId/projectId para fluxo direto

## Validação
- npm run build

Closes #61