### PR TITLE
fix(auth): manter sessao apos F5

### DIFF
--- a/src/api/http.js
+++ b/src/api/http.js
@@ -6,17 +6,45 @@ import axios from "axios";
 // - Se preferir chamar a API diretamente, defina VITE_API_URL="http://localhost:5000/api" no .env.
 const baseURL =
   import.meta.env.VITE_API_URL?.replace(/\/$/, "") || "/api";
-let inMemoryAccessToken = null;
+const ACCESS_TOKEN_STORAGE_KEY = "pw_access_token";
+
+function readStoredAccessToken() {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(ACCESS_TOKEN_STORAGE_KEY);
+    return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredAccessToken(token) {
+  if (typeof window === "undefined") return;
+  try {
+    if (typeof token === "string" && token.trim().length > 0) {
+      window.localStorage.setItem(ACCESS_TOKEN_STORAGE_KEY, token.trim());
+      return;
+    }
+    window.localStorage.removeItem(ACCESS_TOKEN_STORAGE_KEY);
+  } catch {
+    // ignore storage errors
+  }
+}
+
+let inMemoryAccessToken = readStoredAccessToken();
 
 export function setAccessToken(token) {
-  inMemoryAccessToken =
+  const normalizedToken =
     typeof token === "string" && token.trim().length > 0
       ? token.trim()
       : null;
+  inMemoryAccessToken = normalizedToken;
+  writeStoredAccessToken(normalizedToken);
 }
 
 export function clearAccessToken() {
   inMemoryAccessToken = null;
+  writeStoredAccessToken(null);
 }
 
 export function getAccessToken() {

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
-import api, { clearAccessToken, setAccessToken } from "../api/http";
+import api, { clearAccessToken, getAccessToken, setAccessToken } from "../api/http";
 
 const AuthContext = createContext();
 
@@ -52,6 +52,28 @@ export function AuthProvider({ children }) {
     let alive = true;
 
     const bootstrapSession = async () => {
+      const storedToken = getAccessToken();
+      if (storedToken) {
+        try {
+          const decoded = decodeJwtPayload(storedToken);
+          if (!decoded || isExpired(decoded)) {
+            throw new Error("Stored token expired.");
+          }
+
+          const mapped = mapUserFromClaims(decoded);
+          if (mapped?.email) {
+            setToken(storedToken);
+            setUser(mapped);
+            setIsBootstrapping(false);
+            return;
+          }
+        } catch {
+          clearAccessToken();
+          setToken(null);
+          setUser(null);
+        }
+      }
+
       try {
         // Bootstrap via cookie-backed session when available.
         const { data } = await api.get("/profile/me", {


### PR DESCRIPTION
Closes #62\n\n## O que foi feito\n- Persistencia do access token em localStorage no cliente HTTP\n- Restore automatico do token no bootstrap da sessao\n- AuthContext agora reidrata usuario/token no load e evita logout forçado ao F5\n\n## Validacao\n- npm run build