### PR TITLE
fix(events): move winner central CTA from dashboard to events page

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -264,14 +264,9 @@ export default function Dashboard() {
         <div className="container hero-inner">
           <div className="flex items-center justify-between">
             <h1 className="text-xl font-semibold">Bem vindo de volta, Escritor.</h1>
-            <div className="flex items-center gap-2">
-              <Link to="/winner" className="button no-underline">
-                Central do vencedor
-              </Link>
-              <button type="button" className="btn-primary" onClick={openNewProjectModal}>
-                + Novo projeto
-              </button>
-            </div>
+            <button type="button" className="btn-primary" onClick={openNewProjectModal}>
+              + Novo projeto
+            </button>
           </div>
 
           {error && <p className="text-red-600 mt-2">{error}</p>}

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -19,6 +19,7 @@ import {
   buildFallbackParticipantStatus,
   makeParticipantStatusKey,
   normalizeParticipantStatus,
+  resolveParticipantJourney,
 } from "../utils/participantJourney";
 
 function getApiErrorMessage(error) {
@@ -143,6 +144,23 @@ export default function Events() {
     }
     return fallback;
   }, [normalizedMyEvents, participantStatuses, activeEventsById]);
+
+  const winnerCentralTarget = useMemo(() => {
+    for (const entry of normalizedMyEvents) {
+      if (!entry.eventId || !entry.projectId) continue;
+      const key = makeParticipantStatusKey(entry.eventId, entry.projectId);
+      const status = statusByEntry[key];
+      if (!status) continue;
+      const journey = resolveParticipantJourney(status);
+      if (journey.primaryAction === "winner") {
+        return {
+          eventId: entry.eventId,
+          projectId: entry.projectId,
+        };
+      }
+    }
+    return null;
+  }, [normalizedMyEvents, statusByEntry]);
 
   useEffect(() => {
     let mounted = true;
@@ -301,11 +319,27 @@ export default function Events() {
   return (
     <header className="hero">
       <div className="container hero-inner">
-        <div>
-          <h1 className="text-4xl font-serif font-semibold text-gray-900">Eventos</h1>
-          <p className="text-gray-600 mt-2">
-            Participe de desafios de escrita e acompanhe seu desempenho.
-          </p>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-4xl font-serif font-semibold text-gray-900">Eventos</h1>
+            <p className="text-gray-600 mt-2">
+              Participe de desafios de escrita e acompanhe seu desempenho.
+            </p>
+          </div>
+
+          {winnerCentralTarget && (
+            <button
+              type="button"
+              className="button"
+              onClick={() =>
+                navigate(
+                  `/winner?eventId=${winnerCentralTarget.eventId}&projectId=${winnerCentralTarget.projectId}`
+                )
+              }
+            >
+              Central do vencedor
+            </button>
+          )}
         </div>
 
         <section>


### PR DESCRIPTION
## Resumo\n- remove o CTA global 'Central do vencedor' do dashboard\n- mantém o acesso à central apenas no contexto de eventos elegíveis\n- backport do commit 0cafbdc8 para staging\n\n## Contexto\nA correção já havia sido mergeada em main no PR #73, mas ainda não estava presente em staging.\n\nCloses #72