### PR TITLE
fix(dashboard): sync Word Sprint saves with Hoje

### DIFF
--- a/src/components/TodayTargetCard.jsx
+++ b/src/components/TodayTargetCard.jsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { getActiveEvents, getEventProjectProgress } from "../api/events";
 import { getProjectHistory } from "../api/projects";
+import { toYMDLocal } from "../utils/overviewAggregation";
 
 /**
  * Mostra: Hoje, Meta de hoje, Faltam (hoje), Modo (Evento ou Projeto).
@@ -29,11 +30,11 @@ export default function TodayTargetCard({ project }) {
       try {
         const hist = await getProjectHistory(projectId);
         const now = new Date(); now.setHours(0,0,0,0);
-        const key = now.toISOString().slice(0,10);
+        const key = toYMDLocal(now);
         const v = (hist || [])
           .filter(h => {
             const d = new Date(h.date || h.Date || h.createdAt || h.CreatedAt);
-            return d.toISOString().slice(0,10) === key;
+            return toYMDLocal(d) === key;
           })
           .reduce((sum, h) => sum + (Number(h.wordsWritten ?? h.WordsWritten ?? h.words ?? 0) || 0), 0);
         setTodayWords(v);

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -17,7 +17,7 @@ import WritingHeatmap from "../components/WritingHeatmap.jsx";
 import TodayTargetCard from "../components/TodayTargetCard.jsx";
 import RecentBadges from "../components/RecentBadges.jsx";
 import ProjectForm from "../components/ProjectForm.jsx";
-import { isOngoing } from "../utils/overviewAggregation";
+import { isOngoing, toYMDLocal } from "../utils/overviewAggregation";
 
 export default function Dashboard() {
   const [projects, setProjects] = useState([]);
@@ -144,7 +144,7 @@ export default function Dashboard() {
                 );
                 if (d < start || d > end) return;
 
-                const key = d.toISOString().slice(0, 10);
+                const key = toYMDLocal(d);
                 const add = Number(
                   h.wordsWritten ?? h.WordsWritten ?? h.words ?? 0
                 ) || 0;
@@ -169,16 +169,16 @@ export default function Dashboard() {
         for (let i = 0; i < totalDays; i++) {
           const d = new Date(gridStart);
           d.setDate(gridStart.getDate() + i);
-          const key = d.toISOString().slice(0, 10);
+          const key = toYMDLocal(d);
           days.push({ date: key, value: map.get(key) || 0 });
         }
 
-        const todayKey = end.toISOString().slice(0, 10);
+        const todayKey = toYMDLocal(end);
         let streak = 0;
         const probe = new Date(end);
 
         while (true) {
-          const k = probe.toISOString().slice(0, 10);
+          const k = toYMDLocal(probe);
           const v = map.get(k) || 0;
           if (v > 0) {
             streak++;

--- a/src/utils/overviewAggregation.js
+++ b/src/utils/overviewAggregation.js
@@ -1,7 +1,7 @@
 // src/utils/overviewAggregation.js
 
 // Helper: date -> 'YYYY-MM-DD' local
-function toYMDLocal(date) {
+export function toYMDLocal(date) {
   const d = new Date(date);
   if (Number.isNaN(d.getTime())) return null;
   const y = d.getFullYear();


### PR DESCRIPTION
Resumo
- corrige agregação diária do Dashboard e do card Meta de hoje para usar data local
- elimina o deslocamento por UTC que fazia o Word Sprint não refletir em "Hoje"

Arquivos
- src/utils/overviewAggregation.js
- src/pages/Dashboard.jsx
- src/components/TodayTargetCard.jsx

Validação
- npm run build