### PR TITLE
fix(editor): preserve rich export formatting

### DIFF
--- a/src/utils/exportText.js
+++ b/src/utils/exportText.js
@@ -682,7 +682,7 @@ function buildPdfDocumentFromPages(pages) {
   );
 
   Object.entries(PDF_FONT_RESOURCES).forEach(([key, baseFont]) => {
-    objects.set(fontIds[key], `<< /Type /Font /Subtype /Type1 /BaseFont ${baseFont} >>`);
+    objects.set(fontIds[key], `<< /Type /Font /Subtype /Type1 /BaseFont ${baseFont} /Encoding /WinAnsiEncoding >>`);
   });
 
   const fontResourceList = Object.entries(fontIds)


### PR DESCRIPTION
## Resumo\n- corrige exportacao DOCX para documento Word valido\n- preserva a formatacao rica do editor na exportacao PDF\n- aplica codificacao compativel com acentos no PDF\n\n## Validacao\n- npm run build