### PR TITLE
release: ship frontend smoke stabilization to main

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -60,6 +60,42 @@ jobs:
       - name: Build
         run: npm run build
 
+  smoke_e2e:
+    name: Smoke E2E
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.action != 'rollback'
+    runs-on: ubuntu-latest
+    needs:
+      - build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke E2E
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report
+            test-results
+          if-no-files-found: ignore
+
   deploy_staging:
     name: Deploy Staging
     runs-on:
@@ -68,6 +104,7 @@ jobs:
       - deploy
     needs:
       - build
+      - smoke_e2e
     if: (github.event_name == 'push' && github.ref == 'refs/heads/staging') || (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy' && github.event.inputs.target == 'staging')
     environment: staging
     env:
@@ -165,6 +202,7 @@ jobs:
       - deploy
     needs:
       - build
+      - smoke_e2e
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'deploy' && github.event.inputs.target == 'production'
     environment: production
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules/
 # Build output
 dist/
 build/
+playwright-report/
+test-results/
 
 # Logs
 npm-debug.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "recharts": "^3.1.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^5.0.2",
@@ -783,6 +784,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -2606,6 +2623,53 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "axios": "^1.7.2",
@@ -21,6 +22,7 @@
     "recharts": "^3.1.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^5.0.2",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,25 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 30_000,
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    headless: true,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 4173 --strictPort",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -1,0 +1,287 @@
+import { expect, test } from "@playwright/test";
+
+function createJwt(user = {}) {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" })
+  ).toString("base64url");
+
+  const payload = Buffer.from(
+    JSON.stringify({
+      nameid: user.id ?? "user-1",
+      sub: user.id ?? "user-1",
+      email: user.email ?? "writer@planwriter.test",
+      isAdmin: !!user.isAdmin,
+      mustChangePassword: !!user.mustChangePassword,
+      exp: Math.floor(Date.now() / 1000) + 60 * 60,
+    })
+  ).toString("base64url");
+
+  return `${header}.${payload}.signature`;
+}
+
+function createAuthSession(user = {}) {
+  return {
+    accessToken: createJwt(user),
+    refreshToken: "refresh-token-test",
+    refreshTokenExpiresAtUtc: new Date(
+      Date.now() + 24 * 60 * 60 * 1000
+    ).toISOString(),
+  };
+}
+
+function createMockState() {
+  const user = {
+    id: "user-1",
+    email: "writer@planwriter.test",
+    isAdmin: false,
+    mustChangePassword: false,
+  };
+
+  const project = {
+    id: "project-1",
+    title: "Projeto Base",
+    description: "Projeto inicial",
+    genre: "Romance",
+    wordCountGoal: 50000,
+    currentWordCount: 1200,
+    status: "ONGOING",
+  };
+
+  return {
+    user,
+    authSession: createAuthSession(user),
+    projects: [project],
+    statsByProjectId: {
+      "project-1": {
+        totalWords: 1200,
+        averagePerDay: 300,
+        activeDays: 3,
+        bestDay: {
+          date: "2026-02-27T00:00:00Z",
+          words: 500,
+        },
+      },
+    },
+    historyByProjectId: {
+      "project-1": [
+        {
+          date: "2026-02-26T00:00:00Z",
+          wordsWritten: 200,
+          createdAt: "2026-02-26T10:00:00Z",
+        },
+        {
+          date: "2026-02-27T00:00:00Z",
+          wordsWritten: 500,
+          createdAt: "2026-02-27T10:00:00Z",
+        },
+      ],
+    },
+    myEvents: [],
+    activeEvents: [],
+    progressPosts: [],
+  };
+}
+
+async function seedAuthenticatedSession(page, state) {
+  const session = state.authSession;
+  await page.addInitScript((seed) => {
+    window.localStorage.setItem("pw_access_token", seed.accessToken);
+    window.localStorage.setItem("pw_refresh_token", seed.refreshToken);
+    window.localStorage.setItem(
+      "pw_refresh_token_expires_at_utc",
+      seed.refreshTokenExpiresAtUtc
+    );
+  }, session);
+}
+
+async function installApiMocks(page, state) {
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const { pathname } = url;
+
+    if (!pathname.startsWith("/api/")) {
+      return route.continue();
+    }
+
+    const method = request.method();
+
+    const fulfillJson = (data, status = 200) =>
+      route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify(data),
+      });
+
+    if (pathname === "/api/auth/login" && method === "POST") {
+      return fulfillJson(state.authSession);
+    }
+
+    if (pathname === "/api/auth/refresh" && method === "POST") {
+      return fulfillJson(state.authSession);
+    }
+
+    if (pathname === "/api/profile/me" && method === "GET") {
+      return fulfillJson(state.user);
+    }
+
+    if (pathname === "/api/projects" && method === "GET") {
+      return fulfillJson(state.projects);
+    }
+
+    if (pathname === "/api/projects" && method === "POST") {
+      const body = request.postDataJSON();
+      const created = {
+        id: `project-${state.projects.length + 1}`,
+        title: body.title,
+        description: body.description ?? "",
+        genre: body.genre ?? "Outro",
+        wordCountGoal: Number(body.wordCountGoal ?? 50000),
+        currentWordCount: 0,
+        status: "ONGOING",
+      };
+
+      state.projects = [created, ...state.projects];
+      state.statsByProjectId[created.id] = {
+        totalWords: 0,
+        averagePerDay: 0,
+        activeDays: 0,
+        bestDay: null,
+      };
+      state.historyByProjectId[created.id] = [];
+
+      return fulfillJson(created, 201);
+    }
+
+    if (pathname === "/api/projects/monthly" && method === "GET") {
+      return fulfillJson({ total: 1200, month: "2026-02" });
+    }
+
+    if (pathname === "/api/events/my" && method === "GET") {
+      return fulfillJson(state.myEvents);
+    }
+
+    if (pathname === "/api/events/active" && method === "GET") {
+      return fulfillJson(state.activeEvents);
+    }
+
+    const recentBadgesMatch = pathname.match(/^\/api\/badges\/projectId\/([^/]+)$/);
+    if (recentBadgesMatch && method === "GET") {
+      return fulfillJson([]);
+    }
+
+    const statsMatch = pathname.match(/^\/api\/projects\/([^/]+)\/stats$/);
+    if (statsMatch && method === "GET") {
+      const projectId = statsMatch[1];
+      return fulfillJson(
+        state.statsByProjectId[projectId] ?? {
+          totalWords: 0,
+          averagePerDay: 0,
+          activeDays: 0,
+          bestDay: null,
+        }
+      );
+    }
+
+    const historyMatch = pathname.match(/^\/api\/projects\/([^/]+)\/history$/);
+    if (historyMatch && method === "GET") {
+      const projectId = historyMatch[1];
+      return fulfillJson(state.historyByProjectId[projectId] ?? []);
+    }
+
+    const progressMatch = pathname.match(/^\/api\/projects\/([^/]+)\/progress$/);
+    if (progressMatch && method === "POST") {
+      const projectId = progressMatch[1];
+      const body = request.postDataJSON();
+      state.progressPosts.push({ projectId, body });
+
+      return fulfillJson({ message: "Progress added successfully." });
+    }
+
+    return fulfillJson(
+      {
+        message: `Unhandled mock: ${method} ${pathname}`,
+      },
+      404
+    );
+  });
+}
+
+test("login flow persists across reload", async ({ page }) => {
+  const state = createMockState();
+  await installApiMocks(page, state);
+
+  await page.goto("/login");
+  await expect(page.locator('input[type="email"]')).toBeVisible();
+
+  await page.locator('input[type="email"]').fill("writer@planwriter.test");
+  await page.locator('input[type="password"]').fill("Segura123!");
+  await page.getByRole("button", { name: /^Entrar$/ }).click();
+
+  await expect(page).toHaveURL(/\/dashboard$/);
+  await expect(page.getByText("Bem vindo de volta, Escritor.")).toBeVisible();
+
+  await page.reload();
+  await expect(page).toHaveURL(/\/dashboard$/);
+  await expect(page.getByText("Seus projetos")).toBeVisible();
+});
+
+test("dashboard can create a new project through the modal", async ({ page }) => {
+  const state = createMockState();
+  await installApiMocks(page, state);
+  await seedAuthenticatedSession(page, state);
+
+  await page.goto("/dashboard");
+  await expect(page.getByText("Bem vindo de volta, Escritor.")).toBeVisible();
+
+  await page.getByRole("button", { name: /Novo projeto/i }).click();
+  await expect(page.getByRole("heading", { name: "Novo Projeto" })).toBeVisible();
+
+  await page.locator('input[name="title"]').fill("Projeto QA");
+  await page.locator('select[name="genre"]').selectOption("Ficção Científica");
+  await page.locator('textarea[name="description"]').fill("Projeto criado pelo smoke test.");
+  await page.getByRole("button", { name: /^Criar projeto$/ }).click();
+
+  await expect(page.getByText("Projeto criado com sucesso")).toBeVisible();
+  await page.getByRole("button", { name: "Continuar" }).click();
+
+  await expect(page.getByText("Projeto QA")).toBeVisible();
+});
+
+test("editor saves progress and exports txt, docx and pdf", async ({ page }) => {
+  const state = createMockState();
+  await installApiMocks(page, state);
+  await seedAuthenticatedSession(page, state);
+
+  await page.goto("/editor");
+  await expect(page.getByText("Editor de texto")).toBeVisible();
+  await expect(page.locator('[contenteditable="true"]')).toBeVisible();
+
+  const editor = page.locator('[contenteditable="true"]').first();
+  await editor.click();
+  await page.keyboard.type("Texto com acentuação: ação, coração e edição.");
+
+  await expect(page.getByText("Palavras no texto")).toBeVisible();
+  await expect(page.getByRole("button", { name: /Salvar no projeto/ })).toBeEnabled();
+
+  await page.getByRole("button", { name: /Salvar no projeto/ }).click();
+  await expect(
+    page.getByText("Progresso salvo no projeto")
+  ).toBeVisible();
+  await expect.poll(() => state.progressPosts.length).toBe(1);
+  await expect(state.progressPosts[0].body.wordsWritten).toBeGreaterThan(0);
+  await page.getByRole("button", { name: "OK" }).click();
+  await expect(page.getByText("Progresso salvo no projeto")).not.toBeVisible();
+
+  const txtDownload = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Exportar TXT" }).click();
+  await expect((await txtDownload).suggestedFilename()).toMatch(/\.txt$/);
+
+  const docxDownload = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Exportar DOCX" }).click();
+  await expect((await docxDownload).suggestedFilename()).toMatch(/\.docx$/);
+
+  const pdfDownload = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Exportar PDF" }).click();
+  await expect((await pdfDownload).suggestedFilename()).toMatch(/\.pdf$/);
+});


### PR DESCRIPTION
Summary
- add Playwright smoke tests for critical frontend flows
- enforce smoke E2E in the frontend pipeline before deploy
- keep main aligned with staging for stabilization coverage

Validation
- npm run build
- npm run test:e2e