### PR TITLE
fix(auth): clear stale session expired notice

### DIFF
--- a/src/api/http.js
+++ b/src/api/http.js
@@ -142,6 +142,7 @@ export function setAuthSession(session) {
   setAccessToken(normalized.accessToken);
   setRefreshToken(normalized.refreshToken);
   setRefreshTokenExpiresAtUtc(normalized.refreshTokenExpiresAtUtc);
+  clearAuthNotice();
   return normalized;
 }
 
@@ -163,6 +164,10 @@ export function persistAuthNotice(reason) {
   } catch {
     // ignore storage errors
   }
+}
+
+export function clearAuthNotice() {
+  persistAuthNotice(null);
 }
 
 export function consumeAuthNotice() {

--- a/src/components/LoginModal.jsx
+++ b/src/components/LoginModal.jsx
@@ -43,6 +43,12 @@ export default function LoginModal({
   }, [open, initialMode]);
 
   useEffect(() => {
+    if (!open || !showSessionExpiredNotice) {
+      hasShownSessionNoticeRef.current = false;
+    }
+  }, [open, showSessionExpiredNotice]);
+
+  useEffect(() => {
     if (!open || !showSessionExpiredNotice || hasShownSessionNoticeRef.current) {
       return;
     }

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import LoginModal from "../components/LoginModal";
-import { consumeAuthNotice } from "../api/http";
+import { clearAuthNotice, consumeAuthNotice } from "../api/http";
 
 export default function Landing() {
   const [open, setOpen] = useState(false);
@@ -35,6 +35,8 @@ export default function Landing() {
 
   const handleCloseModal = () => {
     setOpen(false);
+    setShowSessionExpiredNotice(false);
+    clearAuthNotice();
 
     if (authIntent || sessionReason) {
       navigate("/", { replace: true });


### PR DESCRIPTION
## Summary\n- clear the stored session-expired notice when a valid session is established\n- reset the landing page expired-session state when the login modal closes\n- avoid re-showing the expired-session warning unless a new real expiration happens\n\n## Validation\n- npm install\n- npm run build