### PR TITLE
feat(events): clarify winner final journey

### DIFF
--- a/src/components/EventParticipantJourneyCard.jsx
+++ b/src/components/EventParticipantJourneyCard.jsx
@@ -20,8 +20,12 @@ export default function EventParticipantJourneyCard({
 
   const primaryHandler = handlers[journey.primaryAction] || onOpenDetails || null;
   const primaryLabel = primaryHandler ? journey.primaryLabel : "Detalhes";
-  const showSecondaryDetails = Boolean(
-    onOpenDetails && journey.primaryAction !== "details"
+  const primaryTone = journey.primaryAction === "details" ? "secondary" : "primary";
+  const secondaryHandler = journey.secondaryAction
+    ? handlers[journey.secondaryAction] || null
+    : null;
+  const showSecondaryAction = Boolean(
+    secondaryHandler && journey.secondaryAction !== journey.primaryAction
   );
 
   return (
@@ -36,28 +40,31 @@ export default function EventParticipantJourneyCard({
         won={status?.isWinner}
         onAction={primaryHandler || undefined}
         actionLabel={primaryLabel}
+        actionTone={primaryTone}
       />
 
       <div className="rounded-xl border border-[#eadfce] bg-[#fffaf2] p-4">
-        <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <span
             className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${journey.badgeClass}`}
           >
             {journey.label}
           </span>
-
-          {showSecondaryDetails && (
-            <button
-              type="button"
-              className="button"
-              onClick={onOpenDetails}
-            >
-              Ver detalhes
-            </button>
-          )}
         </div>
 
         <p className="mt-2 text-sm text-gray-700">{journey.message}</p>
+
+        {showSecondaryAction && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="button"
+              onClick={secondaryHandler}
+            >
+              {journey.secondaryLabel}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/EventProgressStatusCard.jsx
+++ b/src/components/EventProgressStatusCard.jsx
@@ -14,6 +14,7 @@ export default function EventProgressStatusCard({
   won = false,
   onAction,
   actionLabel = "Detalhes",
+  actionTone = "secondary",
   className = "",
 }) {
   const safePercent = Math.min(100, Math.max(0, Math.round(Number(percent ?? 0))));
@@ -62,7 +63,7 @@ export default function EventProgressStatusCard({
           <button
             type="button"
             onClick={onAction}
-            className="px-4 py-2 border rounded-lg"
+            className={actionTone === "primary" ? "btn-primary" : "px-4 py-2 border rounded-lg"}
           >
             {actionLabel}
           </button>

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -19,7 +19,6 @@ import {
   buildFallbackParticipantStatus,
   makeParticipantStatusKey,
   normalizeParticipantStatus,
-  resolveParticipantJourney,
 } from "../utils/participantJourney";
 
 function getApiErrorMessage(error) {
@@ -144,23 +143,6 @@ export default function Events() {
     }
     return fallback;
   }, [normalizedMyEvents, participantStatuses, activeEventsById]);
-
-  const winnerCentralTarget = useMemo(() => {
-    for (const entry of normalizedMyEvents) {
-      if (!entry.eventId || !entry.projectId) continue;
-      const key = makeParticipantStatusKey(entry.eventId, entry.projectId);
-      const status = statusByEntry[key];
-      if (!status) continue;
-      const journey = resolveParticipantJourney(status);
-      if (journey.primaryAction === "winner") {
-        return {
-          eventId: entry.eventId,
-          projectId: entry.projectId,
-        };
-      }
-    }
-    return null;
-  }, [normalizedMyEvents, statusByEntry]);
 
   useEffect(() => {
     let mounted = true;
@@ -326,20 +308,6 @@ export default function Events() {
               Participe de desafios de escrita e acompanhe seu desempenho.
             </p>
           </div>
-
-          {winnerCentralTarget && (
-            <button
-              type="button"
-              className="button"
-              onClick={() =>
-                navigate(
-                  `/winner?eventId=${winnerCentralTarget.eventId}&projectId=${winnerCentralTarget.projectId}`
-                )
-              }
-            >
-              Central do vencedor
-            </button>
-          )}
         </div>
 
         <section>

--- a/src/pages/WinnerGoodies.jsx
+++ b/src/pages/WinnerGoodies.jsx
@@ -7,6 +7,7 @@ import {
   getEventParticipantStatus,
   getMyEvents,
 } from "../api/events";
+import { resolveParticipantJourney } from "../utils/participantJourney";
 
 const TECHNICAL_ERROR_REGEX =
   /system\.|exception|stack trace|nullable object|materialization|sql|guid|invalidoperationexception|request failed with status code/i;
@@ -533,6 +534,10 @@ export default function WinnerGoodies() {
     return Math.max(0, goodies.remainingWords ?? goodies.targetWords - goodies.totalWords);
   }, [goodies]);
 
+  const journey = useMemo(
+    () => (goodies ? resolveParticipantJourney(goodies) : null),
+    [goodies]
+  );
   const statusMeta = useMemo(() => getStatusMeta(goodies?.eligibility?.status), [goodies?.eligibility?.status]);
   const blockedReason = useMemo(() => getGoodieBlockedReason(goodies), [goodies]);
   const eventStatusLabel = useMemo(
@@ -636,6 +641,7 @@ export default function WinnerGoodies() {
   const shareText = goodies
     ? `Concluí minha meta no ${goodies.eventName} com o projeto \"${goodies.projectTitle}\" no PlanWriter! 🎉`
     : "";
+  const showValidateCta = journey?.primaryAction === "validate" && goodies?.eventId && goodies?.projectId;
 
   return (
     <div className="container py-6 space-y-4">
@@ -683,13 +689,16 @@ export default function WinnerGoodies() {
         {!loadingGoodies && goodies && (
           <div className="mt-4 rounded-xl border border-[var(--line)] bg-[var(--surface)] p-4">
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <p className="text-sm font-semibold">Status de elegibilidade</p>
-              <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${statusMeta.className}`}>
-                {statusMeta.label}
+              <div>
+                <p className="text-sm font-semibold">Jornada final do evento</p>
+                <p className="mt-1 text-sm text-gray-700">
+                  {journey?.message || goodies.eligibility.message}
+                </p>
+              </div>
+              <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${journey?.badgeClass || statusMeta.className}`}>
+                {journey?.label || statusMeta.label}
               </span>
             </div>
-
-            <p className="mt-2 text-sm text-gray-700">{goodies.eligibility.message}</p>
 
             <p className="mt-1 text-sm text-gray-600">
               Progresso: {formatWords(goodies.totalWords)} / {formatWords(goodies.targetWords)} palavras
@@ -704,6 +713,27 @@ export default function WinnerGoodies() {
               <p className="mt-2 text-xs text-amber-700 font-medium">
                 Motivo do bloqueio: {goodies.validationBlockReason}
               </p>
+            )}
+
+            {showValidateCta && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  className="btn-primary"
+                  onClick={() =>
+                    navigate(`/validate?eventId=${goodies.eventId}&projectId=${goodies.projectId}`)
+                  }
+                >
+                  {journey.primaryLabel}
+                </button>
+                <button
+                  type="button"
+                  className="button"
+                  onClick={() => navigate(`/events/${goodies.eventId}`)}
+                >
+                  Ver detalhes do evento
+                </button>
+              </div>
             )}
           </div>
         )}

--- a/src/utils/participantJourney.js
+++ b/src/utils/participantJourney.js
@@ -122,8 +122,15 @@ export function resolveParticipantJourney(status) {
       message: "Não foi possível carregar seu status agora.",
       primaryAction: "details",
       primaryLabel: "Detalhes",
+      secondaryAction: null,
+      secondaryLabel: "",
     };
   }
+
+  const isClosedLike =
+    status.isEventClosed ||
+    status.eventStatus === "closed" ||
+    status.eventStatus === "disabled";
 
   if (status.isValidated && status.isWinner) {
     return {
@@ -132,26 +139,29 @@ export function resolveParticipantJourney(status) {
       badgeClass: "bg-emerald-100 text-emerald-700",
       message: "Validação concluída. Goodies de vencedor liberados.",
       primaryAction: "winner",
-      primaryLabel: "Baixar goodies",
+      primaryLabel: "Central do vencedor",
+      secondaryAction: "details",
+      secondaryLabel: "Ver detalhes",
     };
   }
 
   if (status.isValidated) {
     return {
       key: "validated",
-      label: "Validado",
-      badgeClass: "bg-green-100 text-green-700",
-      message: `Projeto validado em ${formatDate(status.validatedAtUtc) || "data recente"}.`,
-      primaryAction: "details",
-      primaryLabel: "Ver resultado",
+      label: "Validado sem liberação",
+      badgeClass: "bg-slate-100 text-slate-700",
+      message:
+        status.validationBlockReason ||
+        status.eligibilityMessage ||
+        `Projeto validado em ${formatDate(status.validatedAtUtc) || "data recente"}, mas os goodies não foram liberados.`,
+      primaryAction: "winner",
+      primaryLabel: "Entender bloqueio",
+      secondaryAction: "details",
+      secondaryLabel: "Ver detalhes",
     };
   }
 
   if (status.canValidate || status.eligibilityStatus === "pending_validation") {
-    const isClosedLike =
-      status.isEventClosed ||
-      status.eventStatus === "closed" ||
-      status.eventStatus === "disabled";
     return {
       key: isClosedLike ? "pending-validation" : "ready",
       label: isClosedLike ? "Pendente de validação" : "Apto para validar",
@@ -162,10 +172,12 @@ export function resolveParticipantJourney(status) {
         "Meta atingida. Faça a validação final para liberar os goodies.",
       primaryAction: "validate",
       primaryLabel: "Validar agora",
+      secondaryAction: isClosedLike ? "winner" : "details",
+      secondaryLabel: isClosedLike ? "Ver status final" : "Ver detalhes",
     };
   }
 
-  if (status.isEventClosed) {
+  if (isClosedLike) {
     const hasWindowBlock =
       String(status.validationBlockReason ?? "").toLowerCase().includes("janela");
     if (hasWindowBlock) {
@@ -174,8 +186,10 @@ export function resolveParticipantJourney(status) {
         label: "Janela encerrada",
         badgeClass: "bg-amber-100 text-amber-800",
         message: status.validationBlockReason,
-        primaryAction: "details",
-        primaryLabel: "Ver resultado",
+        primaryAction: "winner",
+        primaryLabel: "Entender bloqueio",
+        secondaryAction: "details",
+        secondaryLabel: "Ver detalhes",
       };
     }
 
@@ -187,8 +201,10 @@ export function resolveParticipantJourney(status) {
         status.validationBlockReason ||
         status.eligibilityMessage ||
         "Evento encerrado sem elegibilidade de vencedor.",
-      primaryAction: "details",
-      primaryLabel: "Ver resultado",
+      primaryAction: "winner",
+      primaryLabel: "Entender bloqueio",
+      secondaryAction: "details",
+      secondaryLabel: "Ver detalhes",
     };
   }
 
@@ -202,5 +218,7 @@ export function resolveParticipantJourney(status) {
         : status.eligibilityMessage || "Continue escrevendo para progredir no evento.",
     primaryAction: "project",
     primaryLabel: "Continuar no projeto",
+    secondaryAction: "details",
+    secondaryLabel: "Ver detalhes",
   };
 }


### PR DESCRIPTION
## Summary\n- route post-event states to explicit CTAs instead of generic details\n- keep the winner central navigation inside event cards and remove the page-level shortcut\n- reuse the same journey messaging inside the goodies central so validate/blocking states stay consistent\n\n## Validation\n- npm run build