### PR TITLE
feat(editor): add local autosave and draft recovery

### DIFF
--- a/src/pages/FocusEditor.jsx
+++ b/src/pages/FocusEditor.jsx
@@ -1031,6 +1031,7 @@ export default function FocusEditor() {
           </button>
           <select
             className="input h-11 w-[150px]"
+            aria-label="Formato de exportação"
             value={exportFormat}
             onChange={(event) => setExportFormat(event.target.value)}
             disabled={!plainText.trim()}

--- a/tests/e2e/smoke.spec.js
+++ b/tests/e2e/smoke.spec.js
@@ -273,15 +273,18 @@ test("editor saves progress and exports txt, docx and pdf", async ({ page }) => 
   await page.getByRole("button", { name: "OK" }).click();
   await expect(page.getByText("Progresso salvo no projeto")).not.toBeVisible();
 
+  await page.getByRole("combobox", { name: "Formato de exportação" }).selectOption("txt");
   const txtDownload = page.waitForEvent("download");
-  await page.getByRole("button", { name: "Exportar TXT" }).click();
+  await page.getByRole("button", { name: "Exportar" }).click();
   await expect((await txtDownload).suggestedFilename()).toMatch(/\.txt$/);
 
+  await page.getByRole("combobox", { name: "Formato de exportação" }).selectOption("doc");
   const docxDownload = page.waitForEvent("download");
-  await page.getByRole("button", { name: "Exportar DOCX" }).click();
+  await page.getByRole("button", { name: "Exportar" }).click();
   await expect((await docxDownload).suggestedFilename()).toMatch(/\.docx$/);
 
+  await page.getByRole("combobox", { name: "Formato de exportação" }).selectOption("pdf");
   const pdfDownload = page.waitForEvent("download");
-  await page.getByRole("button", { name: "Exportar PDF" }).click();
+  await page.getByRole("button", { name: "Exportar" }).click();
   await expect((await pdfDownload).suggestedFilename()).toMatch(/\.pdf$/);
 });


### PR DESCRIPTION
Closes #102\n\n## O que mudou\n- adiciona autosave local do editor por projeto\n- exibe indicador de ultimo autosave\n- recupera ou descarta rascunho ao reabrir o editor\n- preserva o ultimo draft salvo ao limpar o texto\n- unifica exportacao em seletor de formato + botao exportar\n- atualiza smoke test do editor para a nova UI\n\n## Validacao\n- npm run build