### PR TITLE
style(editor): connect tabs with full panel

### DIFF
--- a/src/pages/FocusEditor.jsx
+++ b/src/pages/FocusEditor.jsx
@@ -1194,7 +1194,7 @@ export default function FocusEditor() {
                 Modo sprint
               </button>
             </div>
-            <div className="-mt-px rounded-b-2xl rounded-tr-2xl border border-black/10 bg-white/70 px-4 py-4 shadow-sm space-y-4">
+            <div className="-mt-px rounded-r-[22px] rounded-b-[22px] border border-black/10 bg-white/70 px-4 py-4 shadow-sm space-y-4">
               <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted">
                 <span>Rascunho local separado por projeto.</span>
                 <span>


### PR DESCRIPTION
## Summary
- connect the editor mode tabs to the full content panel down to draft history
- keep the classic tab look while removing the broken first-row-only box effect
- preserve the current editor behavior and layout outside the tabs panel

## Testing
- npm run build
