### PR TITLE
style(editor): connect tabs through draft history

### DIFF
--- a/src/pages/FocusEditor.jsx
+++ b/src/pages/FocusEditor.jsx
@@ -1165,36 +1165,38 @@ export default function FocusEditor() {
           <p className="text-muted mt-2">
             Escreva no modo livre ou ative uma sprint sem sair do editor.
           </p>
-          <div className="mt-4">
-            <div className="relative z-10 inline-flex items-end gap-1 rounded-t-xl border border-b-0 border-black/10 bg-[#d7d4cf] px-2 pt-2 shadow-sm">
-              <button
-                type="button"
-                className={`relative rounded-t-lg border px-5 py-2.5 text-sm font-medium transition ${
-                  !isSprintMode
-                    ? "top-px border-black/15 border-b-white bg-white text-ink shadow-sm"
-                    : "border-black/10 border-b-transparent bg-[#ece8e1] text-[#4b5563] hover:bg-[#f6f3ed]"
-                }`}
-                onClick={() => handleModeChange("free")}
-                disabled={running}
-                aria-pressed={!isSprintMode}
-              >
-                Modo livre
-              </button>
-              <button
-                type="button"
-                className={`relative rounded-t-lg border px-5 py-2.5 text-sm font-medium transition ${
-                  isSprintMode
-                    ? "top-px border-black/15 border-b-white bg-white text-ink shadow-sm"
-                    : "border-black/10 border-b-transparent bg-[#ece8e1] text-[#4b5563] hover:bg-[#f6f3ed]"
-                }`}
-                onClick={() => handleModeChange("sprint")}
-                disabled={running}
-                aria-pressed={isSprintMode}
-              >
-                Modo sprint
-              </button>
+          <div className="mt-4 overflow-hidden rounded-[28px] border border-black/10 bg-white/70 shadow-sm">
+            <div className="border-b border-black/10 bg-[#d7d4cf] px-3 pt-3">
+              <div className="inline-flex items-end gap-1">
+                <button
+                  type="button"
+                  className={`relative rounded-t-lg border px-5 py-2.5 text-sm font-medium transition ${
+                    !isSprintMode
+                      ? "top-px border-black/15 border-b-white bg-white text-ink shadow-sm"
+                      : "border-black/10 border-b-transparent bg-[#ece8e1] text-[#4b5563] hover:bg-[#f6f3ed]"
+                  }`}
+                  onClick={() => handleModeChange("free")}
+                  disabled={running}
+                  aria-pressed={!isSprintMode}
+                >
+                  Modo livre
+                </button>
+                <button
+                  type="button"
+                  className={`relative rounded-t-lg border px-5 py-2.5 text-sm font-medium transition ${
+                    isSprintMode
+                      ? "top-px border-black/15 border-b-white bg-white text-ink shadow-sm"
+                      : "border-black/10 border-b-transparent bg-[#ece8e1] text-[#4b5563] hover:bg-[#f6f3ed]"
+                  }`}
+                  onClick={() => handleModeChange("sprint")}
+                  disabled={running}
+                  aria-pressed={isSprintMode}
+                >
+                  Modo sprint
+                </button>
+              </div>
             </div>
-            <div className="-mt-px rounded-r-[22px] rounded-b-[22px] border border-black/10 bg-white/70 px-4 py-4 shadow-sm space-y-4">
+            <div className="space-y-4 px-4 py-4">
               <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted">
                 <span>Rascunho local separado por projeto.</span>
                 <span>


### PR DESCRIPTION
## Summary\n- wrap the editor mode tabs and panel content in a single bordered container\n- keep the border continuous from the tab rail to the end of draft history\n- preserve the current editor layout and behavior\n\n## Testing\n- npm run build