### PR TITLE
feat(editor): sync rich draft with backend

### DIFF
--- a/src/api/projects.js
+++ b/src/api/projects.js
@@ -14,6 +14,24 @@ export const getProject = async (id) => {
   return data;
 };
 
+export const getProjectDraft = async (projectId) => {
+  const response = await api.get(`/projects/${projectId}/draft`, {
+    validateStatus: (status) => status === 204 || (status >= 200 && status < 300),
+  });
+
+  if (response.status === 204 || !response.data) {
+    return null;
+  }
+
+  const htmlContent = response.data.htmlContent ?? response.data.HtmlContent ?? "";
+  return String(htmlContent).trim() ? response.data : null;
+};
+
+export const saveProjectDraft = async (projectId, htmlContent) => {
+  const { data } = await api.put(`/projects/${projectId}/draft`, { htmlContent });
+  return data;
+};
+
 // =====================
 // Histórico (progresso)
 // BACKEND: GET /projects/{id}/history

--- a/src/pages/FocusEditor.jsx
+++ b/src/pages/FocusEditor.jsx
@@ -29,7 +29,12 @@ import {
   Undo2,
   Unlink2,
 } from "lucide-react";
-import { addProgress, getProjects } from "../api/projects";
+import {
+  addProgress,
+  getProjectDraft,
+  getProjects,
+  saveProjectDraft,
+} from "../api/projects";
 import FeedbackModal from "../components/FeedbackModal.jsx";
 import {
   exportHtmlAsDoc,
@@ -198,6 +203,29 @@ function createDraftPayload(
     wordCount: countWords(plain),
     previewText: plain.slice(0, 180),
   };
+}
+
+function resolveProjectLabel(projects, projectId) {
+  return (
+    projects.find((project) => String(project.id ?? project.projectId) === String(projectId))
+      ?.title ??
+    projects.find((project) => String(project.id ?? project.projectId) === String(projectId))
+      ?.name ??
+    "Sem projeto"
+  );
+}
+
+function mapRemoteDraftToLocal(projects, projectId, draft) {
+  const htmlContent = draft?.htmlContent ?? draft?.HtmlContent ?? "";
+  const updatedAt =
+    draft?.updatedAtUtc ?? draft?.UpdatedAtUtc ?? draft?.updatedAt ?? draft?.UpdatedAt;
+
+  return createDraftPayload(
+    projectId,
+    resolveProjectLabel(projects, projectId),
+    htmlContent,
+    updatedAt || new Date().toISOString()
+  );
 }
 
 function appendStoredDraftVersion(projectId, snapshot, options = {}) {
@@ -522,6 +550,7 @@ export default function FocusEditor() {
   const autosaveTimeoutRef = useRef(null);
   const autosaveSuspendedRef = useRef(true);
   const currentScopeRef = useRef(null);
+  const remoteSaveSequenceRef = useRef({});
 
   const plainText = useMemo(() => htmlToPlainText(contentHtml), [contentHtml]);
   const wordCount = useMemo(() => countWords(plainText), [plainText]);
@@ -596,16 +625,11 @@ export default function FocusEditor() {
         return;
       }
 
-      const projectLabel =
-        projects.find(
-          (project) => String(project.id ?? project.projectId) === String(projectId)
-        )?.title ??
-        projects.find(
-          (project) => String(project.id ?? project.projectId) === String(projectId)
-        )?.name ??
-        "Sem projeto";
-
-      const payload = createDraftPayload(projectId, projectLabel, normalizedHtml);
+      const payload = createDraftPayload(
+        projectId,
+        resolveProjectLabel(projects, projectId),
+        normalizedHtml
+      );
       let nextHistory = readStoredDraftVersions(projectId);
 
       if (
@@ -621,25 +645,82 @@ export default function FocusEditor() {
         setLastAutosavedAt(payload.updatedAt);
         setDraftHistory(nextHistory);
       }
+
+      if (!projectId) {
+        return;
+      }
+
+      const nextSequence = (remoteSaveSequenceRef.current[scopeKey] ?? 0) + 1;
+      remoteSaveSequenceRef.current[scopeKey] = nextSequence;
+
+      void (async () => {
+        try {
+          const remoteDraft = await saveProjectDraft(projectId, normalizedHtml);
+
+          if (remoteSaveSequenceRef.current[scopeKey] !== nextSequence) {
+            return;
+          }
+
+          const remotePayload = mapRemoteDraftToLocal(projects, projectId, remoteDraft);
+          setStoredDraft(projectId, remotePayload);
+
+          if (currentScopeRef.current === scopeKey) {
+            setLastAutosavedAt(remotePayload.updatedAt);
+            setDraftHistory(readStoredDraftVersions(projectId));
+          }
+        } catch (error) {
+          console.error("Erro ao sincronizar rascunho remoto:", error);
+        }
+      })();
     },
     [projects]
   );
 
   const initializeDraftForProject = useCallback(
-    (projectId) => {
+    async (projectId) => {
       const scopeKey = getDraftScopeKey(projectId);
       currentScopeRef.current = scopeKey;
       autosaveSuspendedRef.current = true;
       window.clearTimeout(autosaveTimeoutRef.current);
 
-      const storedDraft = readStoredDraft(projectId);
       const storedHistory = readStoredDraftVersions(projectId);
+      const storedDraft = readStoredDraft(projectId);
 
       setContentHtml("");
       setDraftHistory(storedHistory);
       if (editorRef.current) {
         editorRef.current.innerHTML = "";
       }
+
+      if (!projectId) {
+        if (storedDraft?.contentHtml) {
+          setDraftPrompt(storedDraft);
+          setLastAutosavedAt(storedDraft.updatedAt ?? null);
+          return;
+        }
+
+        setDraftPrompt(null);
+        setLastAutosavedAt(null);
+        autosaveSuspendedRef.current = false;
+        return;
+      }
+
+      try {
+        const remoteDraft = await getProjectDraft(projectId);
+        if (currentScopeRef.current !== scopeKey) return;
+
+        if (remoteDraft) {
+          const remotePayload = mapRemoteDraftToLocal(projects, projectId, remoteDraft);
+          setStoredDraft(projectId, remotePayload);
+          setDraftPrompt(remotePayload);
+          setLastAutosavedAt(remotePayload.updatedAt ?? null);
+          return;
+        }
+      } catch (error) {
+        console.error("Erro ao carregar rascunho remoto:", error);
+      }
+
+      if (currentScopeRef.current !== scopeKey) return;
 
       if (storedDraft?.contentHtml) {
         setDraftPrompt(storedDraft);
@@ -651,7 +732,7 @@ export default function FocusEditor() {
       setLastAutosavedAt(null);
       autosaveSuspendedRef.current = false;
     },
-    []
+    [projects]
   );
 
   const refreshToolbarState = useCallback(() => {
@@ -981,6 +1062,12 @@ export default function FocusEditor() {
       editorRef.current.innerHTML = "";
       editorRef.current.focus();
     }
+
+    if (selectedProjectId) {
+      void saveProjectDraft(selectedProjectId, "").catch((error) => {
+        console.error("Erro ao limpar rascunho remoto:", error);
+      });
+    }
   };
 
   const handleRestoreDraft = () => {
@@ -1006,6 +1093,12 @@ export default function FocusEditor() {
     if (editorRef.current) {
       editorRef.current.innerHTML = "";
       editorRef.current.focus();
+    }
+
+    if (selectedProjectId) {
+      void saveProjectDraft(selectedProjectId, "").catch((error) => {
+        console.error("Erro ao descartar rascunho remoto:", error);
+      });
     }
   };
 
@@ -1198,11 +1291,11 @@ export default function FocusEditor() {
             </div>
             <div className="space-y-4 px-4 py-4">
               <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted">
-                <span>Rascunho local separado por projeto.</span>
+                <span>Rascunho do editor separado por projeto.</span>
                 <span>
                   {lastAutosavedAt
                     ? `Último autosave: ${formatDraftTimestamp(lastAutosavedAt)}`
-                    : "Nenhum rascunho salvo localmente neste projeto."}
+                    : "Nenhum rascunho salvo neste projeto."}
                 </span>
               </div>
 


### PR DESCRIPTION
## Summary
- load the remote project draft when opening the unified editor
- sync autosave writes to the backend while preserving local fallback and history
- keep explicit clear/discard actions mirrored to the remote draft

## Validation
- npm run build

## Staging validation
1. Open the editor with a project, type rich text, wait for autosave, and reload.
2. Confirm the remote draft is restored for the same project.
3. Change the draft, wait for autosave, reload, and confirm the latest version wins.
4. Switch to another project and confirm drafts stay isolated.
5. Simulate a backend failure and confirm the local fallback still preserves the draft.