### PR TITLE
feat(auth): recuperar e redefinir senha no frontend

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 // src/App.jsx
 import { Suspense, lazy, useState } from "react";
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 
 import Navbar from "./components/Navbar.jsx";
 import LoginPopover from "./components/LoginPopover.jsx";
@@ -44,6 +44,19 @@ function RouteFallback() {
   );
 }
 
+function ResetPasswordRedirect() {
+  const location = useLocation();
+  const query = new URLSearchParams(location.search);
+  const token = query.get("token");
+  const target = new URLSearchParams({ auth: "reset" });
+
+  if (token) {
+    target.set("token", token);
+  }
+
+  return <Navigate to={`/?${target.toString()}`} replace />;
+}
+
 export default function App() {
   const [loginOpen, setLoginOpen] = useState(false);
   const [anchorEl, setAnchorEl] = useState(null);
@@ -63,6 +76,8 @@ export default function App() {
         <Route path="/" element={<Landing />} />
         <Route path="/login" element={<Login />} />
         <Route path="/register" element={<Navigate to="/?auth=register" replace />} />
+        <Route path="/forgot-password" element={<Navigate to="/?auth=forgot" replace />} />
+        <Route path="/reset-password" element={<ResetPasswordRedirect />} />
         <Route path="/resources" element={<Resources />} />
         <Route path="/u/:slug" element={<PublicProfile />} />
 

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -50,6 +50,21 @@ export async function logoutAllSessions() {
   );
 }
 
+export async function forgotPassword({ email }) {
+  const { data } = await api.post("/auth/forgot-password", {
+    Email: email,
+  });
+  return data;
+}
+
+export async function resetPassword({ token, newPassword }) {
+  const { data } = await api.post("/auth/reset-password", {
+    Token: token,
+    NewPassword: newPassword,
+  });
+  return data;
+}
+
 export function logout() {
   return logoutSession();
 }

--- a/src/api/http.js
+++ b/src/api/http.js
@@ -237,7 +237,9 @@ function isPublicAuthRequest(url) {
   return (
     normalized.includes("/auth/login") ||
     normalized.includes("/auth/register") ||
-    normalized.includes("/auth/refresh")
+    normalized.includes("/auth/refresh") ||
+    normalized.includes("/auth/forgot-password") ||
+    normalized.includes("/auth/reset-password")
   );
 }
 

--- a/src/components/LoginModal.jsx
+++ b/src/components/LoginModal.jsx
@@ -1,21 +1,45 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { loginApi, register } from "../api/auth";
+import { forgotPassword, loginApi, register, resetPassword } from "../api/auth";
 import { useAuth } from "../context/AuthContext";
 import FeedbackModal from "./FeedbackModal.jsx";
-import { getAuthFriendlyMessage, getRegisterFriendlyMessage } from "../utils/authErrorMessage";
+import {
+  getAuthFriendlyMessage,
+  getRecoveryFriendlyMessage,
+  getRegisterFriendlyMessage,
+} from "../utils/authErrorMessage";
 import { resolvePostAuthPathFromUser } from "../utils/authRedirect";
+
+const VALID_MODES = new Set(["login", "register", "forgot", "reset"]);
+
+function normalizeInitialMode(mode) {
+  return VALID_MODES.has(mode) ? mode : "login";
+}
+
+function getModalTitle(mode) {
+  switch (mode) {
+    case "register":
+      return "Criar conta";
+    case "forgot":
+      return "Recuperar senha";
+    case "reset":
+      return "Redefinir senha";
+    default:
+      return "Entrar";
+  }
+}
 
 export default function LoginModal({
   open,
   onClose,
   initialMode = "login",
+  initialResetToken = "",
   showSessionExpiredNotice = false,
 }) {
   const { login } = useAuth();
   const navigate = useNavigate();
 
-  const [mode, setMode] = useState("login"); // login | register
+  const [mode, setMode] = useState("login");
   const [loading, setLoading] = useState(false);
   const [feedback, setFeedback] = useState({
     open: false,
@@ -23,6 +47,7 @@ export default function LoginModal({
     title: "",
     message: "",
     primaryLabel: "OK",
+    onPrimary: null,
   });
 
   // login fields
@@ -33,14 +58,24 @@ export default function LoginModal({
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [dateOfBirth, setDateOfBirth] = useState("");
+
+  // reset fields
+  const [resetToken, setResetToken] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmNewPassword, setConfirmNewPassword] = useState("");
+
   const hasShownSessionNoticeRef = useRef(false);
 
   useEffect(() => {
     if (!open) return;
+
     setLoading(false);
-    setMode(initialMode === "register" ? "register" : "login");
-    setFeedback((prev) => ({ ...prev, open: false }));
-  }, [open, initialMode]);
+    setMode(normalizeInitialMode(initialMode));
+    setFeedback((prev) => ({ ...prev, open: false, onPrimary: null }));
+    setResetToken(typeof initialResetToken === "string" ? initialResetToken : "");
+    setNewPassword("");
+    setConfirmNewPassword("");
+  }, [open, initialMode, initialResetToken]);
 
   useEffect(() => {
     if (!open || !showSessionExpiredNotice) {
@@ -60,6 +95,7 @@ export default function LoginModal({
       title: "Sua sessão expirou",
       message: "Faça login novamente para continuar de onde parou.",
       primaryLabel: "OK",
+      onPrimary: null,
     });
   }, [open, showSessionExpiredNotice]);
 
@@ -70,6 +106,26 @@ export default function LoginModal({
   }, [open, onClose]);
 
   if (!open) return null;
+
+  const closeFeedback = () => {
+    setFeedback((prev) => ({ ...prev, open: false, onPrimary: null }));
+  };
+
+  const goToLogin = () => {
+    setMode("login");
+    setPassword("");
+    setNewPassword("");
+    setConfirmNewPassword("");
+  };
+
+  const goToRegister = () => {
+    setMode("register");
+  };
+
+  const goToForgot = () => {
+    setMode("forgot");
+    setPassword("");
+  };
 
   const submitLogin = async (e) => {
     e.preventDefault();
@@ -90,6 +146,7 @@ export default function LoginModal({
         title: "Não foi possível entrar",
         message: getAuthFriendlyMessage(ex, "Não foi possível concluir o login. Tente novamente."),
         primaryLabel: "Tentar de novo",
+        onPrimary: null,
       });
     } finally {
       setLoading(false);
@@ -116,6 +173,10 @@ export default function LoginModal({
         title: "Usuário cadastrado com sucesso",
         message: "Faça login para entrar no dashboard.",
         primaryLabel: "Continuar",
+        onPrimary: () => {
+          closeFeedback();
+          goToLogin();
+        },
       });
     } catch (ex) {
       setFeedback({
@@ -124,6 +185,116 @@ export default function LoginModal({
         title: "Falha no cadastro",
         message: getRegisterFriendlyMessage(ex, "Não foi possível concluir o cadastro."),
         primaryLabel: "Fechar",
+        onPrimary: null,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const submitForgotPassword = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+
+    try {
+      const response = await forgotPassword({ email });
+      const responseMessage =
+        typeof response?.message === "string" && response.message.trim()
+          ? response.message.trim()
+          : "Se o email informado existir, as instruções de recuperação foram enviadas.";
+
+      setFeedback({
+        open: true,
+        type: "success",
+        title: "Solicitação recebida",
+        message: responseMessage,
+        primaryLabel: "Voltar para login",
+        onPrimary: () => {
+          closeFeedback();
+          goToLogin();
+          navigate("/?auth=login", { replace: true });
+        },
+      });
+    } catch (ex) {
+      setFeedback({
+        open: true,
+        type: "error",
+        title: "Não foi possível recuperar a senha",
+        message: getRecoveryFriendlyMessage(
+          ex,
+          "Não foi possível enviar as instruções de recuperação no momento."
+        ),
+        primaryLabel: "Fechar",
+        onPrimary: null,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const submitResetPassword = async (e) => {
+    e.preventDefault();
+
+    if (!resetToken.trim()) {
+      setFeedback({
+        open: true,
+        type: "warning",
+        title: "Token obrigatório",
+        message: "Informe o token de recuperação recebido para continuar.",
+        primaryLabel: "OK",
+        onPrimary: null,
+      });
+      return;
+    }
+
+    if (!newPassword || newPassword !== confirmNewPassword) {
+      setFeedback({
+        open: true,
+        type: "warning",
+        title: "Senhas não conferem",
+        message: "A nova senha e a confirmação precisam ser iguais.",
+        primaryLabel: "OK",
+        onPrimary: null,
+      });
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await resetPassword({
+        token: resetToken.trim(),
+        newPassword,
+      });
+
+      const responseMessage =
+        typeof response?.message === "string" && response.message.trim()
+          ? response.message.trim()
+          : "Senha redefinida com sucesso.";
+
+      setFeedback({
+        open: true,
+        type: "success",
+        title: "Senha redefinida",
+        message: responseMessage,
+        primaryLabel: "Ir para login",
+        onPrimary: () => {
+          closeFeedback();
+          goToLogin();
+          setResetToken("");
+          navigate("/?auth=login", { replace: true });
+        },
+      });
+    } catch (ex) {
+      setFeedback({
+        open: true,
+        type: "error",
+        title: "Não foi possível redefinir a senha",
+        message: getRecoveryFriendlyMessage(
+          ex,
+          "Não foi possível redefinir sua senha. Confira o token e tente novamente."
+        ),
+        primaryLabel: "Fechar",
+        onPrimary: null,
       });
     } finally {
       setLoading(false);
@@ -138,9 +309,7 @@ export default function LoginModal({
       <div className="w-full max-w-md rounded-xl bg-white shadow-xl p-6">
         {/* Header */}
         <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold">
-            {mode === "login" ? "Entrar" : "Criar conta"}
-          </h3>
+          <h3 className="text-lg font-semibold">{getModalTitle(mode)}</h3>
           <button
             type="button"
             className="button"
@@ -152,7 +321,7 @@ export default function LoginModal({
         </div>
 
         {/* Form */}
-        {mode === "login" ? (
+        {mode === "login" && (
           <form onSubmit={submitLogin} className="space-y-3">
             <div>
               <label className="label">Email</label>
@@ -177,6 +346,16 @@ export default function LoginModal({
               />
             </div>
 
+            <div className="flex justify-end text-sm">
+              <button
+                type="button"
+                className="text-indigo-600 hover:underline"
+                onClick={goToForgot}
+              >
+                Esqueci minha senha
+              </button>
+            </div>
+
             <button
               className="btn-primary w-full"
               type="submit"
@@ -190,13 +369,15 @@ export default function LoginModal({
               <button
                 type="button"
                 className="text-indigo-600 hover:underline"
-                onClick={() => setMode("register")}
+                onClick={goToRegister}
               >
                 Criar agora
               </button>
             </div>
           </form>
-        ) : (
+        )}
+
+        {mode === "register" && (
           <form onSubmit={submitRegister} className="space-y-3">
             <div className="grid grid-cols-2 gap-3">
               <div>
@@ -265,9 +446,109 @@ export default function LoginModal({
               <button
                 type="button"
                 className="text-indigo-600 hover:underline"
-                onClick={() => setMode("login")}
+                onClick={goToLogin}
               >
                 Entrar
+              </button>
+            </div>
+          </form>
+        )}
+
+        {mode === "forgot" && (
+          <form onSubmit={submitForgotPassword} className="space-y-3">
+            <p className="text-sm text-slate-600">
+              Informe seu email para receber as instruções de redefinição de senha.
+            </p>
+
+            <div>
+              <label className="label">Email</label>
+              <input
+                className="input w-full"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoFocus
+              />
+            </div>
+
+            <button
+              className="btn-primary w-full"
+              type="submit"
+              disabled={loading}
+            >
+              {loading ? "Enviando..." : "Enviar instruções"}
+            </button>
+
+            <div className="text-sm text-center text-slate-500">
+              Lembrou a senha?{" "}
+              <button
+                type="button"
+                className="text-indigo-600 hover:underline"
+                onClick={goToLogin}
+              >
+                Voltar para login
+              </button>
+            </div>
+          </form>
+        )}
+
+        {mode === "reset" && (
+          <form onSubmit={submitResetPassword} className="space-y-3">
+            <p className="text-sm text-slate-600">
+              Informe o token recebido e escolha sua nova senha.
+            </p>
+
+            <div>
+              <label className="label">Token de recuperação</label>
+              <input
+                className="input w-full"
+                type="text"
+                value={resetToken}
+                onChange={(e) => setResetToken(e.target.value)}
+                required
+                autoFocus={!initialResetToken}
+              />
+            </div>
+
+            <div>
+              <label className="label">Nova senha</label>
+              <input
+                className="input w-full"
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                required
+              />
+            </div>
+
+            <div>
+              <label className="label">Confirmar nova senha</label>
+              <input
+                className="input w-full"
+                type="password"
+                value={confirmNewPassword}
+                onChange={(e) => setConfirmNewPassword(e.target.value)}
+                required
+              />
+            </div>
+
+            <button
+              className="btn-primary w-full"
+              type="submit"
+              disabled={loading}
+            >
+              {loading ? "Redefinindo..." : "Redefinir senha"}
+            </button>
+
+            <div className="text-sm text-center text-slate-500">
+              Já recuperou o acesso?{" "}
+              <button
+                type="button"
+                className="text-indigo-600 hover:underline"
+                onClick={goToLogin}
+              >
+                Ir para login
               </button>
             </div>
           </form>
@@ -279,7 +560,8 @@ export default function LoginModal({
         title={feedback.title}
         message={feedback.message}
         primaryLabel={feedback.primaryLabel}
-        onClose={() => setFeedback((prev) => ({ ...prev, open: false }))}
+        onPrimary={feedback.onPrimary || undefined}
+        onClose={closeFeedback}
       />
     </div>
   );

--- a/src/components/LoginPopover.jsx
+++ b/src/components/LoginPopover.jsx
@@ -56,6 +56,11 @@ export default function LoginPopover({ open, anchorEl, onClose }) {
     navigate("/register");
   };
 
+  const handleForgotRedirect = () => {
+    onClose?.();
+    navigate("/forgot-password");
+  };
+
   // --- posicionamento ---
   const rect = anchorEl?.getBoundingClientRect();
   const popoverWidth = 320;
@@ -109,6 +114,16 @@ export default function LoginPopover({ open, anchorEl, onClose }) {
               onChange={(e) => setPassword(e.target.value)}
               required
             />
+          </div>
+
+          <div className="text-right">
+            <button
+              type="button"
+              onClick={handleForgotRedirect}
+              className="text-sm text-indigo-600 hover:underline"
+            >
+              Esqueci minha senha
+            </button>
           </div>
 
           <div className="flex gap-2 mt-2">

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -9,17 +9,22 @@ export default function Landing() {
   const navigate = useNavigate();
 
   const authIntent = searchParams.get("auth");
+  const resetTokenFromQuery = searchParams.get("token") || "";
   const sessionReason = searchParams.get("session");
   const [showSessionExpiredNotice, setShowSessionExpiredNotice] = useState(false);
-  const modalInitialMode = useMemo(
-    () => (authIntent === "register" ? "register" : "login"),
-    [authIntent]
-  );
+  const modalInitialMode = useMemo(() => {
+    if (authIntent === "register") return "register";
+    if (authIntent === "forgot") return "forgot";
+    if (authIntent === "reset") return "reset";
+    return "login";
+  }, [authIntent]);
 
   useEffect(() => {
     if (
       authIntent === "register" ||
       authIntent === "login" ||
+      authIntent === "forgot" ||
+      authIntent === "reset" ||
       sessionReason === "expired"
     ) {
       setOpen(true);
@@ -38,7 +43,7 @@ export default function Landing() {
     setShowSessionExpiredNotice(false);
     clearAuthNotice();
 
-    if (authIntent || sessionReason) {
+    if (authIntent || sessionReason || resetTokenFromQuery) {
       navigate("/", { replace: true });
     }
   };
@@ -112,6 +117,7 @@ export default function Landing() {
         open={open}
         onClose={handleCloseModal}
         initialMode={modalInitialMode}
+        initialResetToken={resetTokenFromQuery}
         showSessionExpiredNotice={showSessionExpiredNotice}
       />
     </>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -67,6 +67,9 @@ export default function Login() {
 
         <div className="hr-soft mt-4"></div>
         <p className="subhead" style={{ marginTop: 12 }}>
+          <Link to="/forgot-password">Esqueci minha senha</Link>
+        </p>
+        <p className="subhead" style={{ marginTop: 8 }}>
           Não tem conta? <Link to="/register">Criar conta</Link>
         </p>
       </div>

--- a/src/utils/authErrorMessage.js
+++ b/src/utils/authErrorMessage.js
@@ -97,3 +97,44 @@ export function getRegisterFriendlyMessage(error, fallbackMessage) {
 
   return fallback;
 }
+
+export function getRecoveryFriendlyMessage(error, fallbackMessage) {
+  const fallback = fallbackMessage || "Não foi possível concluir a recuperação de senha.";
+  const status = error?.response?.status;
+
+  if (status === 400) {
+    const validationMessages = extractValidationMessages(error);
+    if (validationMessages.length > 0) {
+      return validationMessages[0];
+    }
+
+    const rawBadRequest = error?.response?.data;
+    if (typeof rawBadRequest === "string" && rawBadRequest.trim()) {
+      return rawBadRequest.trim();
+    }
+  }
+
+  if (status === 429) {
+    return "Muitas tentativas em pouco tempo. Aguarde um minuto e tente novamente.";
+  }
+
+  if (typeof status === "number" && status >= 500) {
+    return "Estamos com instabilidade no servidor. Tente novamente em instantes.";
+  }
+
+  const apiMessage = error?.response?.data?.message;
+  if (typeof apiMessage === "string" && apiMessage.trim()) {
+    return apiMessage.trim();
+  }
+
+  const rawMessage = error?.message;
+  if (typeof rawMessage === "string" && /^Request failed with status code \d+$/i.test(rawMessage)) {
+    return fallback;
+  }
+
+  if (typeof rawMessage === "string" && rawMessage.trim()) {
+    return rawMessage.trim();
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Resumo
Implementa o fluxo completo de recuperação de senha no frontend (forgot/reset), integrado ao backend já existente.

## O que mudou
- adiciona chamadas de API para `/auth/forgot-password` e `/auth/reset-password`
- libera esses endpoints no `isPublicAuthRequest` para não acionar refresh/redirect indevido
- expande `LoginModal` com modos: `login`, `register`, `forgot`, `reset`
- adiciona deep-link por query string para reset (`/?auth=reset&token=...`)
- adiciona rotas públicas `/forgot-password` e `/reset-password` redirecionando para o modal na landing
- adiciona atalhos de recuperação em `LoginPopover` e `Login`
- melhora mensagens amigáveis de erro para recuperação

## Validação
- `npm run build`

## Observação
- alterações em `node_modules/.vite/*` não foram commitadas (cache local).
