### PR TITLE
fix(auth): streamline reset password modal

### DIFF
--- a/src/components/LoginModal.jsx
+++ b/src/components/LoginModal.jsx
@@ -201,6 +201,10 @@ export default function LoginModal({
 
     try {
       const response = await forgotPassword({ email });
+      const responseMessage =
+        typeof response?.message === "string" && response.message.trim()
+          ? response.message.trim()
+          : "Se o email informado existir, as instruções de recuperação foram geradas.";
       const responseResetToken =
         typeof response?.resetToken === "string" && response.resetToken.trim()
           ? response.resetToken.trim()
@@ -250,10 +254,13 @@ export default function LoginModal({
       setFeedback({
         open: true,
         type: "warning",
-        title: "Token obrigatório",
-        message: "Informe o token de recuperação recebido para continuar.",
-        primaryLabel: "OK",
-        onPrimary: null,
+        title: "Recuperação expirada",
+        message: "Solicite uma nova redefinição de senha para continuar.",
+        primaryLabel: "Gerar novo acesso",
+        onPrimary: () => {
+          closeFeedback();
+          goToForgot();
+        },
       });
       return;
     }


### PR DESCRIPTION
## Resumo\n- remove o fluxo quebrado intermediario na recuperacao de senha\n- vai direto para o modal de redefinicao quando o backend retornar resetToken\n- mantem o token apenas em estado interno, sem exibir ao usuario\n- trata melhor o caso em que o token interno nao existe mais\n\n## Validacao\n- npm run build